### PR TITLE
Refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN wget https://github.com/rizinorg/rizin/archive/refs/tags/v0.7.3.tar.gz && \
 WORKDIR /home/ubuntu
 
 # Download, build and install the latest creait library
-RUN git clone https://github.com/RevEngAI/creait && \
+RUN git clone -b v1 https://github.com/RevEngAI/creait && \
     cd creait && \
     cmake -B build -G Ninja -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=ON && \
     ninja -C build && \

--- a/Source/Cutter/CMakeLists.txt
+++ b/Source/Cutter/CMakeLists.txt
@@ -10,7 +10,8 @@ set(CMAKE_AUTORCC ON) # Auto Resource Compile
 
 # main plugin library and sources
 set(ReaiCutterPluginSource "Cutter.cpp" "../Plugin.c" "Ui/ConfigSetupDialog.cpp" "Ui/Table.cpp"
-                           "Ui/FunctionRenameDialog.cpp" "Ui/FunctionSimilarityDialog.cpp")
+                           "Ui/FunctionRenameDialog.cpp" "Ui/FunctionSimilarityDialog.cpp"
+                           "Ui/AutoAnalysisDialog.cpp")
 add_library(reai_cutter STATIC MODULE ${ReaiCutterPluginSource})
 target_link_libraries(reai_cutter PUBLIC Cutter::Cutter Rizin::Core ${CREAIT_LIBRARIES})
 

--- a/Source/Cutter/CMakeLists.txt
+++ b/Source/Cutter/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_AUTORCC ON) # Auto Resource Compile
 # main plugin library and sources
 set(ReaiCutterPluginSource "Cutter.cpp" "../Plugin.c" "Ui/ConfigSetupDialog.cpp" "Ui/Table.cpp"
                            "Ui/FunctionRenameDialog.cpp" "Ui/FunctionSimilarityDialog.cpp"
-                           "Ui/AutoAnalysisDialog.cpp")
+                           "Ui/AutoAnalysisDialog.cpp" "Ui/CreateAnalysisDialog.cpp")
 add_library(reai_cutter STATIC MODULE ${ReaiCutterPluginSource})
 target_link_libraries(reai_cutter PUBLIC Cutter::Cutter Rizin::Core ${CREAIT_LIBRARIES})
 

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -63,7 +63,7 @@ void reai_plugin_display_msg (ReaiLogLevel level, CString msg) {
     win_title[REAI_LOG_LEVEL_ERROR] = "Error";
     win_title[REAI_LOG_LEVEL_FATAL] = "Critical";
 
-    reai_log_printf (reai_logger(), level, "display", "%s", msg);
+    reai_log_printf (level, "display", "%s", msg);
 
     switch (level) {
         case REAI_LOG_LEVEL_INFO :
@@ -101,7 +101,7 @@ void reai_plugin_display_msg (ReaiLogLevel level, CString msg) {
 void ReaiCutterPlugin::setupPlugin() {
     /* if plugin launch fails then terminate */
     if (!reai_plugin_init()) {
-        LOG_TRACE ("Plugin initialization incomplete.");
+        REAI_LOG_TRACE ("Plugin initialization incomplete.");
     }
 
     /* display dialog to get config settings */
@@ -415,10 +415,13 @@ void ReaiCutterPlugin::on_Setup() {
         setupDialog->setHost (reai_config()->host);
         setupDialog->setApiKey (reai_config()->apikey);
         setupDialog->setModel (reai_config()->model);
-        setupDialog->setLogDirPath (reai_config()->log_dir_path);
     }
 
     int result = setupDialog->exec();
+
+    REAI_LOG_TRACE ("host = %s", setupDialog->getHost());
+    REAI_LOG_TRACE ("api key = %s", setupDialog->getApiKey());
+    REAI_LOG_TRACE ("mode = %s", setupDialog->getModel());
 
     /* move ahead only if OK was pressed. */
     if (result == QDialog::Rejected) {
@@ -427,13 +430,12 @@ void ReaiCutterPlugin::on_Setup() {
         /* if you accept without filling all fields, then dispaly a warning. */
         if (setupDialog->allFieldsFilled()) {
             /* check whether the API key is in the correct format */
-            if (reai_config_check_api_key (setupDialog->getApiKey())) {
+            if (reai_auth_check (reai(), reai_response(), setupDialog->getApiKey())) {
                 /* if we reach here finally then we save the config and exit loop */
                 if (reai_plugin_save_config (
                         setupDialog->getHost(),
                         setupDialog->getApiKey(),
-                        setupDialog->getModel(),
-                        setupDialog->getLogDirPath()
+                        setupDialog->getModel()
                     )) {
                     DISPLAY_INFO (
                         "Config saved successfully to \"%s\".",
@@ -447,7 +449,7 @@ void ReaiCutterPlugin::on_Setup() {
                 }
             } else {
                 DISPLAY_ERROR (
-                    "Invalid API Key. It's recommended to directly copy-paste "
+                    "Invalid API Key. Make sure you're online and directly copy-paste "
                     "the API key from RevEng.AI dashboard."
                 );
                 on_Setup(); /* continue setup */

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -307,8 +307,30 @@ void ReaiCutterPlugin::on_ApplyExistingAnalysis() {
             return;
         }
 
-        if (!reai_plugin_apply_existing_analysis (core, binaryId)) {
-            DISPLAY_ERROR ("Failed to apply existing analysis to this binary file.");
+        QMessageBox::StandardButton reply = QMessageBox::question (
+            (QWidget *)this->parent(),
+            "Apply analysis",
+            "Do you want to rename only unknown functions",
+            QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel
+        );
+
+        switch (reply) {
+            case QMessageBox::Yes : {
+                if (!reai_plugin_apply_existing_analysis (core, binaryId, true)) {
+                    DISPLAY_ERROR ("Failed to apply existing analysis to this binary file.");
+                }
+                break;
+            }
+
+            case QMessageBox::No : {
+                if (!reai_plugin_apply_existing_analysis (core, binaryId, false)) {
+                    DISPLAY_ERROR ("Failed to apply existing analysis to this binary file.");
+                }
+                break;
+            }
+
+            default :
+                break;
         }
     } else {
         DISPLAY_ERROR (
@@ -343,7 +365,14 @@ void ReaiCutterPlugin::on_AutoAnalyzeBinSym() {
         on_Setup();
     }
 
-    if (!reai_plugin_auto_analyze_opened_binary_file (RzCoreLocked (Core()), 0.1, 5, 0.85)) {
+    // TODO: create a new dialog for auto-analysis
+    if (!reai_plugin_auto_analyze_opened_binary_file (
+            RzCoreLocked (Core()),
+            5,
+            0.85,
+            true,
+            false
+        )) {
         DISPLAY_ERROR ("Failed to complete auto-analysis.");
     }
 }

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -99,8 +99,10 @@ void reai_plugin_display_msg (ReaiLogLevel level, CString msg) {
 }
 
 void ReaiCutterPlugin::setupPlugin() {
+    RzCoreLocked core (Core());
+
     /* if plugin launch fails then terminate */
-    if (!reai_plugin_init()) {
+    if (!reai_plugin_init (core)) {
         REAI_LOG_TRACE ("Plugin initialization incomplete.");
         isInitialized = false;
         return;
@@ -228,6 +230,7 @@ ReaiCutterPlugin::~ReaiCutterPlugin() {
         return;
     }
 
+    RzCoreLocked core (Core());
     reai_plugin_deinit();
 }
 
@@ -285,8 +288,10 @@ void ReaiCutterPlugin::on_ApplyExistingAnalysis() {
                               QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel
                           ) == QMessageBox::No;
 
-        if (!reai_plugin_apply_existing_analysis (core, binaryId, applyToAll)) {
-            DISPLAY_ERROR ("Failed to apply existing analysis to this binary file.");
+        if (reai_plugin_apply_existing_analysis (core, binaryId, applyToAll)) {
+            DISPLAY_INFO ("Analysis applied successfully.");
+        } else {
+            DISPLAY_INFO ("Failed to apply existing analysis.");
         }
     } else {
         DISPLAY_ERROR (
@@ -440,7 +445,8 @@ void ReaiCutterPlugin::on_Setup() {
                     reai_config_get_default_path()
                 );
 
-                reai_plugin_init();
+                RzCoreLocked core (Core());
+                reai_plugin_init (core);
             } else {
                 DISPLAY_ERROR ("Failed to save config.");
             }

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -108,9 +108,6 @@ void ReaiCutterPlugin::setupPlugin() {
         return;
     }
 
-    /* display dialog to get config settings */
-    setupDialog = new ConfigSetupDialog ((QWidget *)this->parent());
-
     isInitialized = true;
 };
 
@@ -417,29 +414,25 @@ void ReaiCutterPlugin::on_BinAnalysisHistory() {
 }
 
 void ReaiCutterPlugin::on_Setup() {
+    ConfigSetupDialog *setupDialog = new ConfigSetupDialog ((QWidget *)this->parent());
+
     /* if config already exists then load the config into config setup dialog */
     if (reai_plugin_check_config_exists()) {
         setupDialog->setHost (reai_config()->host);
         setupDialog->setApiKey (reai_config()->apikey);
-        setupDialog->setModel (reai_config()->model);
     }
 
     int result = setupDialog->exec();
 
     REAI_LOG_TRACE ("host = %s", setupDialog->getHost());
     REAI_LOG_TRACE ("api key = %s", setupDialog->getApiKey());
-    REAI_LOG_TRACE ("mode = %s", setupDialog->getModel());
 
     /* move ahead only if OK was pressed. */
     if (result == QDialog::Rejected) {
         return;
     } else {
         if (setupDialog->allFieldsFilled()) {
-            if (reai_plugin_save_config (
-                    setupDialog->getHost(),
-                    setupDialog->getApiKey(),
-                    setupDialog->getModel()
-                )) {
+            if (reai_plugin_save_config (setupDialog->getHost(), setupDialog->getApiKey())) {
                 DISPLAY_INFO (
                     "Config saved successfully to \"%s\".",
                     reai_config_get_default_path()

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -101,8 +101,20 @@ void reai_plugin_display_msg (ReaiLogLevel level, CString msg) {
 void ReaiCutterPlugin::setupPlugin() {
     RzCoreLocked core (Core());
 
-    /* if plugin launch fails then terminate */
     if (!reai_plugin_init (core)) {
+        // if plugin failed to load because no config exists
+        if (!reai_config()) {
+            // show setup dialog
+            on_Setup();
+
+            // if config is loaded then happy happy happy
+            if (reai_config()) {
+                isInitialized = true;
+                return;
+            }
+        }
+
+        // otherwise terminate
         REAI_LOG_TRACE ("Plugin initialization incomplete.");
         isInitialized = false;
         return;

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -273,6 +273,9 @@ void ReaiCutterPlugin::on_ApplyExistingAnalysis() {
             return;
         }
 
+        // TODO: ask user here first whether they want to sync function names?
+        // Not really a priority though
+
         Bool applyToAll = QMessageBox::question (
                               (QWidget *)this->parent(),
                               "Apply analysis",
@@ -283,8 +286,6 @@ void ReaiCutterPlugin::on_ApplyExistingAnalysis() {
         if (!reai_plugin_apply_existing_analysis (core, binaryId, applyToAll)) {
             DISPLAY_ERROR ("Failed to apply existing analysis to this binary file.");
         }
-
-        reai_binary_id() = binaryId;
     } else {
         DISPLAY_ERROR (
             "Failed to get binary id to apply existing analysis. Cannot apply existing analysis."

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -102,6 +102,8 @@ void ReaiCutterPlugin::setupPlugin() {
     /* if plugin launch fails then terminate */
     if (!reai_plugin_init()) {
         REAI_LOG_TRACE ("Plugin initialization incomplete.");
+        isInitialized = false;
+        return;
     }
 
     /* display dialog to get config settings */
@@ -427,32 +429,20 @@ void ReaiCutterPlugin::on_Setup() {
     if (result == QDialog::Rejected) {
         return;
     } else {
-        /* if you accept without filling all fields, then dispaly a warning. */
         if (setupDialog->allFieldsFilled()) {
-            /* check whether the API key is in the correct format */
-            if (reai_auth_check (reai(), reai_response(), setupDialog->getApiKey())) {
-                /* if we reach here finally then we save the config and exit loop */
-                if (reai_plugin_save_config (
-                        setupDialog->getHost(),
-                        setupDialog->getApiKey(),
-                        setupDialog->getModel()
-                    )) {
-                    DISPLAY_INFO (
-                        "Config saved successfully to \"%s\".",
-                        reai_config_get_default_path()
-                    );
-
-                    RzCoreLocked core (Core());
-                    reai_plugin_init();
-                } else {
-                    DISPLAY_ERROR ("Failed to save config.");
-                }
-            } else {
-                DISPLAY_ERROR (
-                    "Invalid API Key. Make sure you're online and directly copy-paste "
-                    "the API key from RevEng.AI dashboard."
+            if (reai_plugin_save_config (
+                    setupDialog->getHost(),
+                    setupDialog->getApiKey(),
+                    setupDialog->getModel()
+                )) {
+                DISPLAY_INFO (
+                    "Config saved successfully to \"%s\".",
+                    reai_config_get_default_path()
                 );
-                on_Setup(); /* continue setup */
+
+                reai_plugin_init();
+            } else {
+                DISPLAY_ERROR ("Failed to save config.");
             }
         } else {
             DISPLAY_WARN ("Not all fields are filled. Please complete the configuration setup.");

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -37,6 +37,7 @@
 #include <Cutter/Ui/ConfigSetupDialog.hpp>
 #include <Cutter/Ui/FunctionRenameDialog.hpp>
 #include <Cutter/Ui/FunctionSimilarityDialog.hpp>
+#include <Cutter/Ui/AutoAnalysisDialog.hpp>
 #include <Plugin.h>
 #include <Cutter/Cutter.hpp>
 
@@ -365,16 +366,10 @@ void ReaiCutterPlugin::on_AutoAnalyzeBinSym() {
         on_Setup();
     }
 
-    // TODO: create a new dialog for auto-analysis
-    if (!reai_plugin_auto_analyze_opened_binary_file (
-            RzCoreLocked (Core()),
-            5,
-            0.85,
-            true,
-            false
-        )) {
-        DISPLAY_ERROR ("Failed to complete auto-analysis.");
-    }
+    RzCoreLocked core (Core());
+
+    AutoAnalysisDialog *autoDlg = new AutoAnalysisDialog ((QWidget *)this->parent(), core);
+    autoDlg->show();
 }
 
 void ReaiCutterPlugin::on_RenameFns() {

--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -10,6 +10,7 @@
 #include "Reai/Types.h"
 #include <Cutter.h>
 #include <Reai/AnalysisInfo.h>
+#include <rz_analysis.h>
 #include <rz_core.h>
 
 /* qt includes */
@@ -384,9 +385,8 @@ void ReaiCutterPlugin::on_RenameFns() {
         PRINT_ERR ("OLDNAME = %s \t NEWNAME= %s", oldNameCstr, newNameCstr);
 
         /* get function id for old name */
-        RzAnalysisFunction *rz_fn =
-            reai_plugin_get_rizin_analysis_function_with_name (core, oldNameCstr);
-        ReaiFunctionId fn_id = reai_plugin_get_function_id_for_rizin_function (core, rz_fn);
+        RzAnalysisFunction *rz_fn = rz_analysis_get_function_byname (core->analysis, oldNameCstr);
+        ReaiFunctionId      fn_id = reai_plugin_get_function_id_for_rizin_function (core, rz_fn);
 
         if (!fn_id) {
             DISPLAY_ERROR (

--- a/Source/Cutter/Cutter.hpp
+++ b/Source/Cutter/Cutter.hpp
@@ -38,11 +38,9 @@ class ReaiCutterPlugin : public QObject, public CutterPlugin {
     QAction *actToggleReaiPlugin = nullptr;
 
     /* revengai's menu item actions */
-    QAction *actUploadBin                = nullptr;
     QAction *actCreateAnalysis           = nullptr;
     QAction *actApplyExistingAnalysis    = nullptr;
-    QAction *actCheckAnalysisStatus      = nullptr;
-    QAction *actAutoAnalyzeBinSym        = nullptr;
+    QAction *actAutoAnalyzeBin           = nullptr;
     QAction *actRenameFns                = nullptr;
     QAction *actFunctionSimilaritySearch = nullptr;
     QAction *actBinAnalysisHistory       = nullptr;
@@ -74,11 +72,9 @@ class ReaiCutterPlugin : public QObject, public CutterPlugin {
     }
 
     void on_ToggleReaiPlugin();
-    void on_UploadBin();
     void on_CreateAnalysis();
     void on_ApplyExistingAnalysis();
-    void on_CheckAnalysisStatus();
-    void on_AutoAnalyzeBinSym();
+    void on_AutoAnalyzeBin();
     void on_RenameFns();
     void on_FunctionSimilaritySearch();
     void on_BinAnalysisHistory();

--- a/Source/Cutter/Cutter.hpp
+++ b/Source/Cutter/Cutter.hpp
@@ -48,9 +48,6 @@ class ReaiCutterPlugin : public QObject, public CutterPlugin {
 
     ReaiBinaryId customAnalysisId = 0;
 
-    /* display dialog to get config settings */
-    ConfigSetupDialog *setupDialog;
-
     Bool isInitialized = false;
 
    public:

--- a/Source/Cutter/Ui/AutoAnalysisDialog.cpp
+++ b/Source/Cutter/Ui/AutoAnalysisDialog.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file      : AutoAnalysisDialog.cpp
+ * @date      : 11th Nov 2024
+ * @author    : Siddharth Mishra (admin@brightprogrammer.in)
+ * @copyright : Copyright (c) 2024 RevEngAI. All Rights Reserved.
+ * */
+
+/* plugin */
+#include <Plugin.h>
+#include <Reai/Api/Reai.h>
+#include <Cutter/Ui/AutoAnalysisDialog.hpp>
+
+/* qt */
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QScrollArea>
+#include <QPushButton>
+#include <QHeaderView>
+#include <QCompleter>
+#include <QLabel>
+
+/* cutter */
+#include <cutter/core/Cutter.h>
+#include <librz/rz_analysis.h>
+
+/* reai */
+#include <Reai/Util/Vec.h>
+#include <sys/stdio.h>
+
+AutoAnalysisDialog::AutoAnalysisDialog (QWidget* parent, RzCore* core) : QDialog (parent) {
+    if (!core) {
+        DISPLAY_ERROR ("Invalid rizin core provided. Cannot find similar functions.");
+        return;
+    }
+
+    mainLayout = new QVBoxLayout;
+    setLayout (mainLayout);
+    setWindowTitle ("Auto Analysis Settings");
+
+    confidenceSlider = new QSlider (Qt::Horizontal);
+    confidenceSlider->setMinimum (1);
+    confidenceSlider->setMaximum (100);
+    confidenceSlider->setValue (90);
+    mainLayout->addWidget (confidenceSlider);
+
+    QLabel* confidenceLabel = new QLabel ("90% min confidence");
+    mainLayout->addWidget (confidenceLabel);
+    connect (confidenceSlider, &QSlider::valueChanged, [confidenceLabel] (int value) {
+        confidenceLabel->setText (QString ("%1 % min confidence").arg (value));
+    });
+
+    enableDebugModeCheckBox = new QCheckBox ("Enable debug mode", this);
+    mainLayout->addWidget (enableDebugModeCheckBox);
+    enableDebugModeCheckBox->setCheckState (Qt::CheckState::Checked);
+
+    renameUnknownFunctionsOnlyCheckBox = new QCheckBox ("Rename unknown functions only", this);
+    mainLayout->addWidget (renameUnknownFunctionsOnlyCheckBox);
+    renameUnknownFunctionsOnlyCheckBox->setCheckState (Qt::CheckState::Checked);
+
+    QHBoxLayout* btnLayout = new QHBoxLayout (this);
+    mainLayout->addLayout (btnLayout);
+
+    QPushButton* okBtn     = new QPushButton ("Ok");
+    QPushButton* cancelBtn = new QPushButton ("Cancel");
+    btnLayout->addWidget (cancelBtn);
+    btnLayout->addWidget (okBtn);
+
+    connect (okBtn, &QPushButton::clicked, this, &AutoAnalysisDialog::on_PerformAutoAnalysis);
+    connect (cancelBtn, &QPushButton::clicked, this, &QDialog::close);
+}
+
+void AutoAnalysisDialog::on_PerformAutoAnalysis() {
+    RzCoreLocked core (Core());
+
+    Float32 confidence = confidenceSlider->value() / 100.f;
+    Bool    debugMode  = enableDebugModeCheckBox->checkState() == Qt::CheckState::Checked;
+    Bool applyToAll = renameUnknownFunctionsOnlyCheckBox->checkState() == Qt::CheckState::Unchecked;
+    Uint32 maxResultCount = 10;
+
+    if (!reai_plugin_auto_analyze_opened_binary_file (
+            core,
+            maxResultCount,
+            confidence,
+            debugMode,
+            applyToAll
+        )) {
+        DISPLAY_ERROR ("Failed to perfom auto-analysis.");
+    }
+}

--- a/Source/Cutter/Ui/AutoAnalysisDialog.cpp
+++ b/Source/Cutter/Ui/AutoAnalysisDialog.cpp
@@ -15,8 +15,6 @@
 #include <QHBoxLayout>
 #include <QScrollArea>
 #include <QPushButton>
-#include <QHeaderView>
-#include <QCompleter>
 #include <QLabel>
 
 /* cutter */
@@ -27,12 +25,7 @@
 #include <Reai/Util/Vec.h>
 #include <sys/stdio.h>
 
-AutoAnalysisDialog::AutoAnalysisDialog (QWidget* parent, RzCore* core) : QDialog (parent) {
-    if (!core) {
-        DISPLAY_ERROR ("Invalid rizin core provided. Cannot find similar functions.");
-        return;
-    }
-
+AutoAnalysisDialog::AutoAnalysisDialog (QWidget* parent) : QDialog (parent) {
     mainLayout = new QVBoxLayout;
     setLayout (mainLayout);
     setWindowTitle ("Auto Analysis Settings");

--- a/Source/Cutter/Ui/AutoAnalysisDialog.hpp
+++ b/Source/Cutter/Ui/AutoAnalysisDialog.hpp
@@ -30,7 +30,7 @@ class AutoAnalysisDialog : public QDialog {
     Q_OBJECT;
 
    public:
-    AutoAnalysisDialog (QWidget* parent, RzCore* core);
+    AutoAnalysisDialog (QWidget* parent);
 
    private:
     QVBoxLayout* mainLayout;

--- a/Source/Cutter/Ui/AutoAnalysisDialog.hpp
+++ b/Source/Cutter/Ui/AutoAnalysisDialog.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file      : AutoAnalysisDialog.hpp
+ * @author    : Siddharth Mishra
+ * @date      : 11th Nov 2024
+ * @copyright : Copyright (c) 2024 RevEngAI. All Rights Reserved.
+ * */
+
+#ifndef REAI_PLUGIN_CUTTER_UI_AUTO_ANALYSIS_DIALOG_HPP
+#define REAI_PLUGIN_CUTTER_UI_AUTO_ANALYSIS_DIALOG_HPP
+
+/* qt */
+#include <QDialog>
+#include <QLineEdit>
+#include <QSlider>
+#include <QTableWidget>
+#include <QCheckBox>
+#include <QVBoxLayout>
+
+/* rizin */
+#include <rz_core.h>
+
+/* reai */
+#include <Reai/Types.h>
+
+/* plugin */
+#include <Table.h>
+
+
+class AutoAnalysisDialog : public QDialog {
+    Q_OBJECT;
+
+   public:
+    AutoAnalysisDialog (QWidget* parent, RzCore* core);
+
+   private:
+    QVBoxLayout* mainLayout;
+    QSlider*     confidenceSlider;
+    QCheckBox*   enableDebugModeCheckBox;
+    QCheckBox*   renameUnknownFunctionsOnlyCheckBox;
+
+    void on_PerformAutoAnalysis();
+};
+
+#endif // REAI_PLUGIN_CUTTER_UI_AUTO_ANALYSIS_DIALOG_HPP

--- a/Source/Cutter/Ui/ConfigSetupDialog.cpp
+++ b/Source/Cutter/Ui/ConfigSetupDialog.cpp
@@ -17,6 +17,8 @@
 ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
     setWindowTitle ("Plugin Configuration Setup");
 
+    setMinimumSize (500, 150);
+
     QVBoxLayout* mainLayout = new QVBoxLayout;
     setLayout (mainLayout);
 
@@ -43,12 +45,6 @@ ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
     );
     ADD_LABEL_INPUT_ROW (hostLabel, "RevEng.AI Host", leHost, "https://api.reveng.ai/v1");
     ADD_LABEL_INPUT_ROW (modelLabel, "RevEng.AI AI Model", leModel, "binnet-0.3");
-    ADD_LABEL_INPUT_ROW (
-        logDirPathLabel,
-        "Plugin Local Log Storage Path",
-        leLogDirPath,
-        reai_plugin_get_default_log_dir_path()
-    );
 
 #undef ADD_LABEL_INPUT_ROW
 
@@ -67,10 +63,7 @@ ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
  * @return false otherwise.
  * */
 Bool ConfigSetupDialog::allFieldsFilled() {
-    return !(
-        leHost->text().isEmpty() || leApiKey->text().isEmpty() || leModel->text().isEmpty() ||
-        leLogDirPath->text().isEmpty()
-    );
+    return !(leHost->text().isEmpty() || leApiKey->text().isEmpty() || leModel->text().isEmpty());
 }
 
 /**
@@ -97,14 +90,6 @@ CString ConfigSetupDialog::getModel() {
     return model.constData();
 }
 
-/**
- * @b Get value of log dir path line edit.
- * */
-CString ConfigSetupDialog::getLogDirPath() {
-    logDirPath = leLogDirPath->text().toLatin1();
-    return logDirPath.constData();
-}
-
 void ConfigSetupDialog::setHost (CString value) {
     leHost->setText (value);
 }
@@ -115,8 +100,4 @@ void ConfigSetupDialog::setApiKey (CString value) {
 
 void ConfigSetupDialog::setModel (CString value) {
     leModel->setText (value);
-}
-
-void ConfigSetupDialog::setLogDirPath (CString value) {
-    leLogDirPath->setText (value);
 }

--- a/Source/Cutter/Ui/ConfigSetupDialog.cpp
+++ b/Source/Cutter/Ui/ConfigSetupDialog.cpp
@@ -44,7 +44,6 @@ ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
         "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
     );
     ADD_LABEL_INPUT_ROW (hostLabel, "RevEng.AI Host", leHost, "https://api.reveng.ai/v1");
-    ADD_LABEL_INPUT_ROW (modelLabel, "RevEng.AI AI Model", leModel, "binnet-0.3");
 
 #undef ADD_LABEL_INPUT_ROW
 
@@ -63,7 +62,7 @@ ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
  * @return false otherwise.
  * */
 Bool ConfigSetupDialog::allFieldsFilled() {
-    return !(leHost->text().isEmpty() || leApiKey->text().isEmpty() || leModel->text().isEmpty());
+    return !(leHost->text().isEmpty() || leApiKey->text().isEmpty());
 }
 
 /**
@@ -82,13 +81,6 @@ CString ConfigSetupDialog::getApiKey() {
     return apiKey.constData();
 }
 
-/**
- * @b Get value of model line edit.
- * */
-CString ConfigSetupDialog::getModel() {
-    model = leModel->text().toLatin1();
-    return model.constData();
-}
 
 void ConfigSetupDialog::setHost (CString value) {
     leHost->setText (value);
@@ -96,8 +88,4 @@ void ConfigSetupDialog::setHost (CString value) {
 
 void ConfigSetupDialog::setApiKey (CString value) {
     leApiKey->setText (value);
-}
-
-void ConfigSetupDialog::setModel (CString value) {
-    leModel->setText (value);
 }

--- a/Source/Cutter/Ui/ConfigSetupDialog.cpp
+++ b/Source/Cutter/Ui/ConfigSetupDialog.cpp
@@ -44,12 +44,6 @@ ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
     ADD_LABEL_INPUT_ROW (hostLabel, "RevEng.AI Host", leHost, "https://api.reveng.ai/v1");
     ADD_LABEL_INPUT_ROW (modelLabel, "RevEng.AI AI Model", leModel, "binnet-0.3");
     ADD_LABEL_INPUT_ROW (
-        dbDirPathLabel,
-        "Plugin Local Database Path",
-        leDbDirPath,
-        reai_plugin_get_default_database_dir_path()
-    );
-    ADD_LABEL_INPUT_ROW (
         logDirPathLabel,
         "Plugin Local Log Storage Path",
         leLogDirPath,
@@ -75,7 +69,7 @@ ConfigSetupDialog::ConfigSetupDialog (QWidget* parent) : QDialog (parent) {
 Bool ConfigSetupDialog::allFieldsFilled() {
     return !(
         leHost->text().isEmpty() || leApiKey->text().isEmpty() || leModel->text().isEmpty() ||
-        leDbDirPath->text().isEmpty() || leLogDirPath->text().isEmpty()
+        leLogDirPath->text().isEmpty()
     );
 }
 
@@ -104,14 +98,6 @@ CString ConfigSetupDialog::getModel() {
 }
 
 /**
- * @b Get value of db dir path line edit.
- * */
-CString ConfigSetupDialog::getDbDirPath() {
-    dbDirPath = leDbDirPath->text().toLatin1();
-    return dbDirPath.constData();
-}
-
-/**
  * @b Get value of log dir path line edit.
  * */
 CString ConfigSetupDialog::getLogDirPath() {
@@ -130,9 +116,7 @@ void ConfigSetupDialog::setApiKey (CString value) {
 void ConfigSetupDialog::setModel (CString value) {
     leModel->setText (value);
 }
-void ConfigSetupDialog::setDbDirPath (CString value) {
-    leDbDirPath->setText (value);
-}
+
 void ConfigSetupDialog::setLogDirPath (CString value) {
     leLogDirPath->setText (value);
 }

--- a/Source/Cutter/Ui/ConfigSetupDialog.hpp
+++ b/Source/Cutter/Ui/ConfigSetupDialog.hpp
@@ -24,7 +24,6 @@ class ConfigSetupDialog : public QDialog {
     QByteArray host;
     QByteArray apiKey;
     QByteArray model;
-    QByteArray logDirPath;
 
    public:
     ConfigSetupDialog (QWidget* parent);
@@ -34,16 +33,14 @@ class ConfigSetupDialog : public QDialog {
     CString getHost();
     CString getApiKey();
     CString getModel();
-    CString getLogDirPath();
 
     void setHost (CString value);
     void setApiKey (CString value);
     void setModel (CString value);
-    void setLogDirPath (CString value);
 
    private:
     QDialogButtonBox* buttonBox;
-    QLineEdit *       leHost, *leApiKey, *leModel, *leLogDirPath;
+    QLineEdit *       leHost, *leApiKey, *leModel;
 
     void on_Ok();
     void on_Cancel();

--- a/Source/Cutter/Ui/ConfigSetupDialog.hpp
+++ b/Source/Cutter/Ui/ConfigSetupDialog.hpp
@@ -32,15 +32,13 @@ class ConfigSetupDialog : public QDialog {
 
     CString getHost();
     CString getApiKey();
-    CString getModel();
 
     void setHost (CString value);
     void setApiKey (CString value);
-    void setModel (CString value);
 
    private:
     QDialogButtonBox* buttonBox;
-    QLineEdit *       leHost, *leApiKey, *leModel;
+    QLineEdit *       leHost, *leApiKey;
 
     void on_Ok();
     void on_Cancel();

--- a/Source/Cutter/Ui/ConfigSetupDialog.hpp
+++ b/Source/Cutter/Ui/ConfigSetupDialog.hpp
@@ -24,7 +24,6 @@ class ConfigSetupDialog : public QDialog {
     QByteArray host;
     QByteArray apiKey;
     QByteArray model;
-    QByteArray dbDirPath;
     QByteArray logDirPath;
 
    public:
@@ -35,18 +34,16 @@ class ConfigSetupDialog : public QDialog {
     CString getHost();
     CString getApiKey();
     CString getModel();
-    CString getDbDirPath();
     CString getLogDirPath();
 
     void setHost (CString value);
     void setApiKey (CString value);
     void setModel (CString value);
-    void setDbDirPath (CString value);
     void setLogDirPath (CString value);
 
    private:
     QDialogButtonBox* buttonBox;
-    QLineEdit *       leHost, *leApiKey, *leModel, *leDbDirPath, *leLogDirPath;
+    QLineEdit *       leHost, *leApiKey, *leModel, *leLogDirPath;
 
     void on_Ok();
     void on_Cancel();

--- a/Source/Cutter/Ui/CreateAnalysisDialog.cpp
+++ b/Source/Cutter/Ui/CreateAnalysisDialog.cpp
@@ -87,13 +87,18 @@ void CreateAnalysisDialog::on_CreateAnalysis() {
         return;
     }
 
-    if (!reai_plugin_create_analysis_for_opened_binary_file (
+    if (reai_plugin_create_analysis_for_opened_binary_file (
             core,
             progName.constData(),
             cmdLineArgs.constData(),
             aiModelName.constData(),
             isPrivate
         )) {
-        DISPLAY_ERROR ("Failed to create new analysis");
+        DISPLAY_INFO ("Analysis created successfully.");
+    } else {
+        DISPLAY_INFO ("Failed to create new analysis analysis.");
     }
+
+
+    close();
 }

--- a/Source/Cutter/Ui/CreateAnalysisDialog.cpp
+++ b/Source/Cutter/Ui/CreateAnalysisDialog.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file      : CreateAnalysisDialog.cpp
+ * @date      : 11th Nov 2024
+ * @author    : Siddharth Mishra (admin@brightprogrammer.in)
+ * @copyright : Copyright (c) 2024 RevEngAI. All Rights Reserved.
+ * */
+
+/* plugin */
+#include <Plugin.h>
+#include <Reai/Api/Reai.h>
+#include <Cutter/Ui/CreateAnalysisDialog.hpp>
+
+/* qt */
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+
+/* cutter */
+#include <cutter/core/Cutter.h>
+#include <librz/rz_analysis.h>
+
+/* reai */
+#include <Reai/Util/Vec.h>
+#include <sys/stdio.h>
+
+CreateAnalysisDialog::CreateAnalysisDialog (QWidget* parent) : QDialog (parent) {
+    mainLayout = new QVBoxLayout;
+    setLayout (mainLayout);
+    setWindowTitle ("Auto Analysis Settings");
+
+    progNameInput = new QLineEdit (this);
+    progNameInput->setPlaceholderText ("Program Name");
+    mainLayout->addWidget (progNameInput);
+
+    cmdLineArgsInput = new QLineEdit (this);
+    cmdLineArgsInput->setPlaceholderText ("Command line arguments");
+    mainLayout->addWidget (cmdLineArgsInput);
+
+    isAnalysisPrivateCheckBox = new QCheckBox ("Enable debug mode", this);
+    mainLayout->addWidget (isAnalysisPrivateCheckBox);
+    isAnalysisPrivateCheckBox->setCheckState (Qt::CheckState::Checked);
+
+    QHBoxLayout* btnLayout = new QHBoxLayout (this);
+    mainLayout->addLayout (btnLayout);
+
+    QPushButton* okBtn     = new QPushButton ("Ok");
+    QPushButton* cancelBtn = new QPushButton ("Cancel");
+    btnLayout->addWidget (cancelBtn);
+    btnLayout->addWidget (okBtn);
+
+    connect (okBtn, &QPushButton::clicked, this, &CreateAnalysisDialog::on_CreateAnalysis);
+    connect (cancelBtn, &QPushButton::clicked, this, &QDialog::close);
+}
+
+void CreateAnalysisDialog::on_CreateAnalysis() {
+    RzCoreLocked core (Core());
+
+    Bool isPrivate = isAnalysisPrivateCheckBox->checkState() == Qt::CheckState::Checked;
+
+    QByteArray progName    = progNameInput->text().toLatin1();
+    QByteArray cmdLineArgs = cmdLineArgsInput->text().toLatin1();
+
+    if (!reai_plugin_create_analysis_for_opened_binary_file (
+            core,
+            progName.constData(),
+            cmdLineArgs.constData(),
+            isPrivate
+        )) {
+        DISPLAY_ERROR ("Failed to create new analysis");
+    }
+}

--- a/Source/Cutter/Ui/CreateAnalysisDialog.cpp
+++ b/Source/Cutter/Ui/CreateAnalysisDialog.cpp
@@ -37,6 +37,11 @@ CreateAnalysisDialog::CreateAnalysisDialog (QWidget* parent) : QDialog (parent) 
     cmdLineArgsInput->setPlaceholderText ("Command line arguments");
     mainLayout->addWidget (cmdLineArgsInput);
 
+    aiModelInput = new QComboBox (this);
+    aiModelInput->setPlaceholderText ("AI Model");
+    REAI_VEC_FOREACH (reai_ai_models(), ai_model, { aiModelInput->addItem (*ai_model); });
+    mainLayout->addWidget (aiModelInput);
+
     isAnalysisPrivateCheckBox = new QCheckBox ("Enable debug mode", this);
     mainLayout->addWidget (isAnalysisPrivateCheckBox);
     isAnalysisPrivateCheckBox->setCheckState (Qt::CheckState::Checked);
@@ -58,6 +63,7 @@ void CreateAnalysisDialog::on_CreateAnalysis() {
 
     Bool isPrivate = isAnalysisPrivateCheckBox->checkState() == Qt::CheckState::Checked;
 
+    QByteArray aiModelName = aiModelInput->currentText().toLatin1();
     QByteArray progName    = progNameInput->text().toLatin1();
     QByteArray cmdLineArgs = cmdLineArgsInput->text().toLatin1();
 
@@ -71,10 +77,21 @@ void CreateAnalysisDialog::on_CreateAnalysis() {
         return;
     }
 
+    if (aiModelName.isEmpty()) {
+        QMessageBox::warning (
+            this,
+            "Create Analysis",
+            "Please select an AI model to be used to create analysis.",
+            QMessageBox::Ok
+        );
+        return;
+    }
+
     if (!reai_plugin_create_analysis_for_opened_binary_file (
             core,
             progName.constData(),
             cmdLineArgs.constData(),
+            aiModelName.constData(),
             isPrivate
         )) {
         DISPLAY_ERROR ("Failed to create new analysis");

--- a/Source/Cutter/Ui/CreateAnalysisDialog.cpp
+++ b/Source/Cutter/Ui/CreateAnalysisDialog.cpp
@@ -61,6 +61,16 @@ void CreateAnalysisDialog::on_CreateAnalysis() {
     QByteArray progName    = progNameInput->text().toLatin1();
     QByteArray cmdLineArgs = cmdLineArgsInput->text().toLatin1();
 
+    if (progName.isEmpty()) {
+        QMessageBox::warning (
+            this,
+            "Create Analysis",
+            "Program Name cannot be empty.",
+            QMessageBox::Ok
+        );
+        return;
+    }
+
     if (!reai_plugin_create_analysis_for_opened_binary_file (
             core,
             progName.constData(),

--- a/Source/Cutter/Ui/CreateAnalysisDialog.hpp
+++ b/Source/Cutter/Ui/CreateAnalysisDialog.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file      : CreateAnalysisDialog.hpp
+ * @author    : Siddharth Mishra
+ * @date      : 11th Nov 2024
+ * @copyright : Copyright (c) 2024 RevEngAI. All Rights Reserved.
+ * */
+
+#ifndef REAI_PLUGIN_CUTTER_UI_CREATE_ANALYSIS_DIALOG_HPP
+#define REAI_PLUGIN_CUTTER_UI_CREATE_ANALYSIS_DIALOG_HPP
+
+/* qt */
+#include <QDialog>
+#include <QLineEdit>
+#include <QSlider>
+#include <QTableWidget>
+#include <QCheckBox>
+#include <QVBoxLayout>
+
+/* rizin */
+#include <rz_core.h>
+
+/* reai */
+#include <Reai/Types.h>
+
+/* plugin */
+#include <Table.h>
+
+
+class CreateAnalysisDialog : public QDialog {
+    Q_OBJECT;
+
+   public:
+    CreateAnalysisDialog (QWidget* parent);
+
+   private:
+    QVBoxLayout* mainLayout;
+    QLineEdit*   progNameInput;
+    QLineEdit*   cmdLineArgsInput;
+    QCheckBox*   isAnalysisPrivateCheckBox;
+
+    void on_CreateAnalysis();
+};
+
+#endif // REAI_PLUGIN_CUTTER_UI_CREATE_ANALYSIS_DIALOG_HPP

--- a/Source/Cutter/Ui/CreateAnalysisDialog.hpp
+++ b/Source/Cutter/Ui/CreateAnalysisDialog.hpp
@@ -15,6 +15,7 @@
 #include <QTableWidget>
 #include <QCheckBox>
 #include <QVBoxLayout>
+#include <QComboBox>
 
 /* rizin */
 #include <rz_core.h>
@@ -34,6 +35,7 @@ class CreateAnalysisDialog : public QDialog {
 
    private:
     QVBoxLayout* mainLayout;
+    QComboBox*   aiModelInput;
     QLineEdit*   progNameInput;
     QLineEdit*   cmdLineArgsInput;
     QCheckBox*   isAnalysisPrivateCheckBox;

--- a/Source/Cutter/Ui/FunctionRenameDialog.cpp
+++ b/Source/Cutter/Ui/FunctionRenameDialog.cpp
@@ -103,7 +103,7 @@ void FunctionRenameDialog::getNameMapping (std::vector<std::pair<QString, QStrin
         const QString& newName = newNameMapTable->item (s, 1)->text();
         map.push_back ({oldName, newName});
 
-        LOG_TRACE (
+        REAI_LOG_TRACE (
             "oldName = \"%s\" \t newName \"%s\"",
             oldName.toLatin1().constData(),
             oldName.toLatin1().constData()

--- a/Source/Cutter/Ui/FunctionRenameDialog.cpp
+++ b/Source/Cutter/Ui/FunctionRenameDialog.cpp
@@ -11,6 +11,7 @@
 
 /* rizin */
 #include <rz_analysis.h>
+#include <cutter/core/Cutter.h>
 
 /* qt */
 #include <QVBoxLayout>
@@ -22,19 +23,16 @@
 #include <QStringListModel>
 #include <QHeaderView>
 
-FunctionRenameDialog::FunctionRenameDialog (QWidget* parent, RzCore* core) : QDialog (parent) {
-    if (!core) {
-        DISPLAY_ERROR ("Invalid rizin core provided. Cannot rename functions.");
-        return;
-    }
-
+FunctionRenameDialog::FunctionRenameDialog (QWidget* parent) : QDialog (parent) {
     QVBoxLayout* mainLayout = new QVBoxLayout;
     setLayout (mainLayout);
     setWindowTitle ("Select Functions To Rename");
 
     /* get function names from binary */
     {
-        if (!core->analysis) {
+        RzCoreLocked core (Core());
+
+        if (!reai_plugin_get_rizin_analysis_function_count (core)) {
             DISPLAY_ERROR ("Rizin analysis not performed yet. Please create rizin analysis first.");
             return;
         }

--- a/Source/Cutter/Ui/FunctionRenameDialog.hpp
+++ b/Source/Cutter/Ui/FunctionRenameDialog.hpp
@@ -27,7 +27,7 @@ class FunctionRenameDialog : public QDialog {
     Q_OBJECT;
 
    public:
-    FunctionRenameDialog (QWidget* parent, RzCore* core);
+    FunctionRenameDialog (QWidget* parent);
 
     void getNameMapping (std::vector<std::pair<QString, QString>>& map);
     Bool isFinished() const {

--- a/Source/Cutter/Ui/FunctionSimilarityDialog.cpp
+++ b/Source/Cutter/Ui/FunctionSimilarityDialog.cpp
@@ -21,6 +21,7 @@
 
 /* cutter */
 #include <cutter/core/Cutter.h>
+#include <librz/rz_analysis.h>
 
 /* reai */
 #include <Reai/Util/Vec.h>
@@ -32,9 +33,7 @@ FunctionSimilarityDialog::FunctionSimilarityDialog (QWidget* parent, RzCore* cor
         return;
     }
 
-    setMinimumSize (960, 540);
-
-    QVBoxLayout* mainLayout = new QVBoxLayout;
+    mainLayout = new QVBoxLayout;
     setLayout (mainLayout);
     setWindowTitle ("Function Similarity Search");
 
@@ -81,6 +80,7 @@ FunctionSimilarityDialog::FunctionSimilarityDialog (QWidget* parent, RzCore* cor
 
         maxResultsInput = new QLineEdit (this);
         maxResultsInput->setPlaceholderText ("Maximum search result count... eg: 5");
+        maxResultsInput->setText ("5");
         searchBarLayout->addWidget (maxResultsInput);
 
         QPushButton* searchButton = new QPushButton ("Search", this);
@@ -107,75 +107,22 @@ FunctionSimilarityDialog::FunctionSimilarityDialog (QWidget* parent, RzCore* cor
             confidenceLabel->setText (QString ("%1 % min confidence").arg (value));
         });
 
-
-        showUniqueResultsCheckBox = new QCheckBox ("Show unique results", this);
-        mainLayout->addWidget (showUniqueResultsCheckBox);
-        showUniqueResultsCheckBox->setCheckState (Qt::CheckState::Checked);
-
         enableDebugModeCheckBox = new QCheckBox ("Enable debug mode", this);
         mainLayout->addWidget (enableDebugModeCheckBox);
         enableDebugModeCheckBox->setCheckState (Qt::CheckState::Checked);
     }
-
-    /* create grid layout with scroll area where new name mappings will
-     * be displayed like a table */
-    {
-        // similarNameSuggestionTable = new QTableWidget (0, 4);
-        // mainLayout->addWidget (similarNameSuggestionTable);
-        //
-        // similarNameSuggestionTable->setHorizontalHeaderLabels (
-        //     {"Function Name", "Confidence", "Function ID", "Binary Name"}
-        // );
-        // // Turn off editing
-        // similarNameSuggestionTable->setEditTriggers (QAbstractItemView::NoEditTriggers);
-        // // Allow columns to stretch as much as posible
-        // similarNameSuggestionTable->horizontalHeader()->setSectionResizeMode (QHeaderView::Stretch);
-
-        resultsTable = reai_plugin_table_create();
-        if (!reai_plugin_table_set_columnsf (
-                resultsTable,
-                "sfns",
-                "Function Name",
-                "Confidence",
-                "Function ID",
-                "Binary Name"
-            )) {
-            DISPLAY_ERROR (
-                "Failed to set table columns information. Failed to create results table. Cannot "
-                "continue"
-            );
-            return;
-        }
-
-        mainLayout->addWidget ((QTableWidget*)resultsTable);
-    }
 }
 
 void FunctionSimilarityDialog::on_FindSimilarNames() {
-    similarNameSuggestionTable->clearContents();
-    similarNameSuggestionTable->setRowCount (0);
-
     RzCoreLocked core (Core());
 
     /* check if function exists or not */
-    const QString&      fnName        = searchBarInput->text();
-    QByteArray          fnNameByteArr = fnName.toLatin1();
-    RzAnalysisFunction* rzFn =
-        reai_plugin_get_rizin_analysis_function_with_name (core, fnNameByteArr.constData());
+    const QString& fnName        = searchBarInput->text();
+    QByteArray     fnNameByteArr = fnName.toLatin1();
+    CString        fnNameCStr    = fnNameByteArr.constData();
 
-    if (!rzFn) {
-        DISPLAY_ERROR ("Provided function name does not exist. Cannot get similar function names.");
-        return;
-    }
-
-    ReaiFunctionId fnId = reai_plugin_get_function_id_for_rizin_function (core, rzFn);
-
-    if (!fnId) {
-        DISPLAY_ERROR (
-            "Failed to get function id of given function. Cannot get similar function names."
-        );
-        return;
-    }
+    Float32 confidence = confidenceSlider->value() / 100.f;
+    Bool    debugMode  = enableDebugModeCheckBox->checkState() == Qt::CheckState::Checked;
 
     QString maxResultCountStr = maxResultsInput->text();
     bool    success           = false;
@@ -186,129 +133,16 @@ void FunctionSimilarityDialog::on_FindSimilarNames() {
         return;
     }
 
-    Float32 confidence  = confidenceSlider->value() / 100.f;
-    Float32 maxDistance = 1 - confidence;
-
-    if (!success) {
-        DISPLAY_ERROR ("Failed to convert confidence input to float.");
-        return;
-    }
-
-    ReaiAnnFnMatchVec* fnMatches = reai_batch_function_symbol_ann (
-        reai(),
-        reai_response(),
-        fnId,
-        nullptr,
+    ReaiPluginTable* resultsTable = reai_plugin_search_for_similar_functions (
+        core,
+        fnNameCStr,
         maxResultCount,
-        maxDistance,
-        nullptr,
-        enableDebugModeCheckBox->checkState()
+        confidence,
+        debugMode
     );
 
-    // Populate table
-    REAI_VEC_FOREACH (fnMatches, fnMatch, {
-        if (showUniqueResultsCheckBox->checkState() == Qt::CheckState::Checked)
-            addUniqueRow (
-                fnMatch->nn_function_name,
-                fnMatch->confidence,
-                fnMatch->nn_function_id,
-                fnMatch->nn_binary_name
-            );
-        else {
-            addRow (
-                fnMatch->nn_function_name,
-                fnMatch->confidence,
-                fnMatch->nn_function_id,
-                fnMatch->nn_binary_name
-            );
-        }
-    });
-}
-
-void FunctionSimilarityDialog::addUniqueRow (
-    CString        fn_name,
-    Float32        confidence,
-    ReaiFunctionId fn_id,
-    CString        binary_name
-) {
-    if (!fn_name) {
-        DISPLAY_ERROR ("Given function name is NULL. Cannot add to table cell.");
-        return;
+    if (resultsTable) {
+        reai_plugin_table_show (resultsTable);
+        reai_plugin_table_destroy (resultsTable);
     }
-
-    if (!fn_id) {
-        DISPLAY_ERROR ("Given function id is invalid. Cannot add to table cell.");
-        return;
-    }
-
-    if (!binary_name) {
-        DISPLAY_ERROR ("Given binary name is NULL. Cannot add to table cell.");
-        return;
-    }
-
-    // Check for duplicates
-    bool duplicate = false;
-    for (int row = 0; row < similarNameSuggestionTable->rowCount(); ++row) {
-        QString val1 = similarNameSuggestionTable->item (row, 0) ?
-                           similarNameSuggestionTable->item (row, 0)->text() :
-                           "";
-        QString val3 = similarNameSuggestionTable->item (row, 2) ?
-                           similarNameSuggestionTable->item (row, 2)->text() :
-                           "";
-        QString val4 = similarNameSuggestionTable->item (row, 3) ?
-                           similarNameSuggestionTable->item (row, 3)->text() :
-                           "";
-
-        if (!QString::compare (val1, QString::fromUtf8 (fn_name)) &&
-            !QString::compare (val3, QString::number (fn_id)) &&
-            !QString::compare (val4, QString::fromUtf8 (binary_name))) {
-            duplicate = true;
-            break;
-        }
-    }
-
-    if (!duplicate) {
-        addRow (fn_name, confidence, fn_id, binary_name);
-
-        LOG_TRACE ("Unique row added to similar name suggestion table.");
-    } else {
-        LOG_TRACE (
-            "Duplicate row detected, not adding to similar name suggestion table in "
-            "FuntionSimilarityDialog."
-        );
-    }
-}
-
-void FunctionSimilarityDialog::addRow (
-    CString        fn_name,
-    Float32        confidence,
-    ReaiFunctionId fn_id,
-    CString        binary_name
-) {
-    if (!fn_name) {
-        DISPLAY_ERROR ("Given function name is NULL. Cannot add to table cell.");
-        return;
-    }
-
-    if (!fn_id) {
-        DISPLAY_ERROR ("Given function id is invalid. Cannot add to table cell.");
-        return;
-    }
-
-    if (!binary_name) {
-        DISPLAY_ERROR ("Given binary name is NULL. Cannot add to table cell.");
-        return;
-    }
-
-
-    // Int32 row = similarNameSuggestionTable->rowCount();
-    // similarNameSuggestionTable->insertRow (row);
-    // similarNameSuggestionTable->setItem (row, 0, new QTableWidgetItem (fn_name));
-    // similarNameSuggestionTable
-    //     ->setItem (row, 1, new QTableWidgetItem (QString::number (confidence)));
-    // similarNameSuggestionTable->setItem (row, 2, new QTableWidgetItem (QString::number (fn_id)));
-    // similarNameSuggestionTable->setItem (row, 3, new QTableWidgetItem (binary_name));
-    reai_plugin_table_add_rowf (resultsTable, fn_name, confidence, fn_id, binary_name);
-
-    LOG_TRACE ("Unique row added to similar name suggestion table.");
 }

--- a/Source/Cutter/Ui/FunctionSimilarityDialog.cpp
+++ b/Source/Cutter/Ui/FunctionSimilarityDialog.cpp
@@ -133,16 +133,13 @@ void FunctionSimilarityDialog::on_FindSimilarNames() {
         return;
     }
 
-    ReaiPluginTable* resultsTable = reai_plugin_search_for_similar_functions (
-        core,
-        fnNameCStr,
-        maxResultCount,
-        confidence,
-        debugMode
-    );
-
-    if (resultsTable) {
-        reai_plugin_table_show (resultsTable);
-        reai_plugin_table_destroy (resultsTable);
+    if (!reai_plugin_search_and_show_similar_functions (
+            core,
+            fnNameCStr,
+            maxResultCount,
+            confidence,
+            debugMode
+        )) {
+        DISPLAY_ERROR ("Failed to get similar functions search result.");
     }
 }

--- a/Source/Cutter/Ui/FunctionSimilarityDialog.cpp
+++ b/Source/Cutter/Ui/FunctionSimilarityDialog.cpp
@@ -26,13 +26,7 @@
 /* reai */
 #include <Reai/Util/Vec.h>
 
-FunctionSimilarityDialog::FunctionSimilarityDialog (QWidget* parent, RzCore* core)
-    : QDialog (parent) {
-    if (!core) {
-        DISPLAY_ERROR ("Invalid rizin core provided. Cannot find similar functions.");
-        return;
-    }
-
+FunctionSimilarityDialog::FunctionSimilarityDialog (QWidget* parent) : QDialog (parent) {
     mainLayout = new QVBoxLayout;
     setLayout (mainLayout);
     setWindowTitle ("Function Similarity Search");
@@ -40,8 +34,9 @@ FunctionSimilarityDialog::FunctionSimilarityDialog (QWidget* parent, RzCore* cor
     /* get function names from binary */
     QStringList fnNamesList;
     {
-        if (!core->analysis) {
-            DISPLAY_ERROR ("Rizin analysis not performed yet. Please create rizin analysis first.");
+        RzCoreLocked core (Core());
+
+        if (!reai_plugin_get_rizin_analysis_function_count (core)) {
             return;
         }
 

--- a/Source/Cutter/Ui/FunctionSimilarityDialog.hpp
+++ b/Source/Cutter/Ui/FunctionSimilarityDialog.hpp
@@ -29,7 +29,7 @@ class FunctionSimilarityDialog : public QDialog {
     Q_OBJECT;
 
    public:
-    FunctionSimilarityDialog (QWidget* parent, RzCore* core);
+    FunctionSimilarityDialog (QWidget* parent);
 
    private:
     QVBoxLayout* mainLayout;

--- a/Source/Cutter/Ui/FunctionSimilarityDialog.hpp
+++ b/Source/Cutter/Ui/FunctionSimilarityDialog.hpp
@@ -14,6 +14,7 @@
 #include <QSlider>
 #include <QTableWidget>
 #include <QCheckBox>
+#include <QVBoxLayout>
 
 /* rizin */
 #include <rz_core.h>
@@ -31,25 +32,13 @@ class FunctionSimilarityDialog : public QDialog {
     FunctionSimilarityDialog (QWidget* parent, RzCore* core);
 
    private:
-    QLineEdit *      searchBarInput, *maxResultsInput;
-    QSlider*         confidenceSlider;
-    QCheckBox*       enableDebugModeCheckBox;
-    QCheckBox*       showUniqueResultsCheckBox;
-    QCompleter*      fnNameCompleter;
-    QTableWidget*    similarNameSuggestionTable;
-    ReaiPluginTable* resultsTable;
+    QVBoxLayout* mainLayout;
+    QLineEdit *  searchBarInput, *maxResultsInput;
+    QSlider*     confidenceSlider;
+    QCheckBox*   enableDebugModeCheckBox;
+    QCompleter*  fnNameCompleter;
 
     void on_FindSimilarNames();
-    void addUniqueRow (
-        CString        fn_name,
-        Float32        confidence,
-        ReaiFunctionId fn_id,
-        CString        binary_name
-    );
-    void addRow (CString fn_name, Float32 confidence, ReaiFunctionId fn_id, CString binary_name);
-
-    // TODO: Add a rename button, that when an entry in table is selected
-    // we can rename the given function name to selected function name
 };
 
 #endif // REAI_PLUGIN_CUTTER_UI_FUNCTION_SIMILARITY_DIALOG_HPP

--- a/Source/Cutter/Ui/Table.cpp
+++ b/Source/Cutter/Ui/Table.cpp
@@ -147,13 +147,13 @@ struct ReaiPluginTable : public QTableWidget {
         Size tableRowCount = rowCount();
         insertRow (tableRowCount);
 
-        LOG_TRACE ("Adding new row at %zu", tableRowCount);
+        REAI_LOG_TRACE ("Adding new row at %zu", tableRowCount);
 
         /* populate the new row */
         for (Int32 i = 0; i < headerLabels.size(); i++) {
             setItem (tableRowCount, i, new QTableWidgetItem (row[i]));
 
-            LOG_TRACE (
+            REAI_LOG_TRACE (
                 "Inserting item \"%s\" at row = %zu and colu = %zu",
                 row[i].toLatin1().constData(),
                 tableRowCount,
@@ -217,14 +217,14 @@ ReaiPluginTable* reai_plugin_table_set_columnsf (ReaiPluginTable* table, const c
     rz_table_set_vcolumnsf (table->rzTable, fmtstr, rzArgs);
     va_end (rzArgs);
 
-    LOG_TRACE ("Setting columns");
+    REAI_LOG_TRACE ("Setting columns");
 
     size_t len = strlen (fmtstr);
     for (size_t i = 0; i < len; ++i) {
         /* all column names are of type CString */
         CString column_name = va_arg (args, CString);
         table->addColumn (column_name);
-        LOG_TRACE ("New column \"%s\"", column_name);
+        REAI_LOG_TRACE ("New column \"%s\"", column_name);
     }
 
     va_end (args);
@@ -271,7 +271,7 @@ ReaiPluginTable* reai_plugin_table_add_rowf (ReaiPluginTable* table, const char*
     void**      cellData = NULL;
     rz_pvector_foreach (rzRow, cellData) {
         CString cellValue = *(CString*)cellData;
-        LOG_TRACE ("Adding cell value \"%s\" to new row", cellValue);
+        REAI_LOG_TRACE ("Adding cell value \"%s\" to new row", cellValue);
         row << cellValue;
     }
 

--- a/Source/Cutter/Ui/Table.cpp
+++ b/Source/Cutter/Ui/Table.cpp
@@ -318,4 +318,16 @@ ReaiPluginTable* reai_plugin_table_set_title (ReaiPluginTable* table, const char
     return table;
 }
 
+ReaiPluginTable* reai_plugin_table_clear_contents (ReaiPluginTable* table) {
+    if (!table) {
+        DISPLAY_ERROR ("Invalid plugin table provided. Cannot set title.");
+        return nullptr;
+    }
+
+    table->clearContents();
+    table->setRowCount (0);
+
+    return table;
+}
+
 #include "Table.moc"

--- a/Source/Override.h
+++ b/Source/Override.h
@@ -63,7 +63,7 @@
         if ((cond)) {                                                                              \
             eprintf (__VA_ARGS__);                                                                 \
             eprintf ("\n");                                                                        \
-            LOG_ERROR (__VA_ARGS__);                                                               \
+            REAI_LOG_ERROR (__VA_ARGS__);                                                          \
             return value;                                                                          \
         }                                                                                          \
     } while (0)
@@ -73,7 +73,7 @@
         if ((cond)) {                                                                              \
             eprintf (__VA_ARGS__);                                                                 \
             eprintf ("\n");                                                                        \
-            LOG_ERROR (__VA_ARGS__);                                                               \
+            REAI_LOG_ERROR (__VA_ARGS__);                                                          \
             return;                                                                                \
         }                                                                                          \
     } while (0)
@@ -82,7 +82,7 @@
     do {                                                                                           \
         eprintf (__VA_ARGS__);                                                                     \
         eprintf ("\n");                                                                            \
-        LOG_ERROR (__VA_ARGS__);                                                                   \
+        REAI_LOG_ERROR (__VA_ARGS__);                                                              \
         goto handler;                                                                              \
     } while (0)
 #define GOTO_HANDLER_IF(cond, handler, ...)                                                        \
@@ -90,7 +90,7 @@
         if ((cond)) {                                                                              \
             eprintf (__VA_ARGS__);                                                                 \
             eprintf ("\n");                                                                        \
-            LOG_ERROR (__VA_ARGS__);                                                               \
+            REAI_LOG_ERROR (__VA_ARGS__);                                                          \
             goto handler;                                                                          \
         }                                                                                          \
     } while (0)
@@ -100,7 +100,7 @@
         if ((cond)) {                                                                              \
             eprintf (__VA_ARGS__);                                                                 \
             eprintf ("\n");                                                                        \
-            LOG_ERROR (__VA_ARGS__);                                                               \
+            REAI_LOG_ERROR (__VA_ARGS__);                                                          \
             handler;                                                                               \
         }                                                                                          \
     } while (0)
@@ -110,7 +110,7 @@
         if ((cond)) {                                                                              \
             eprintf (__VA_ARGS__);                                                                 \
             eprintf ("\n");                                                                        \
-            LOG_FATAL (__VA_ARGS__);                                                               \
+            REAI_LOG_FATAL (__VA_ARGS__);                                                          \
             abort();                                                                               \
         }                                                                                          \
     } while (0)
@@ -120,7 +120,7 @@
         eprintf ("unreachable code reached : ");                                                   \
         eprintf (__VA_ARGS__);                                                                     \
         eprintf ("\n");                                                                            \
-        LOG_ERROR (__VA_ARGS__);                                                                   \
+        REAI_LOG_ERROR (__VA_ARGS__);                                                              \
         return val;                                                                                \
     } while (0)
 
@@ -129,7 +129,7 @@
         eprintf ("unreachable code reached : ");                                                   \
         eprintf (__VA_ARGS__);                                                                     \
         eprintf ("\n");                                                                            \
-        LOG_ERROR (__VA_ARGS__);                                                                   \
+        REAI_LOG_ERROR (__VA_ARGS__);                                                              \
         return;                                                                                    \
     } while (0)
 
@@ -138,7 +138,7 @@
         eprintf ("unreachable code reached : ");                                                   \
         eprintf (__VA_ARGS__);                                                                     \
         eprintf ("\n");                                                                            \
-        LOG_FATAL (__VA_ARGS__);                                                                   \
+        REAI_LOG_FATAL (__VA_ARGS__);                                                              \
         abort();                                                                                   \
     } while (0)
 
@@ -146,7 +146,7 @@
     do {                                                                                           \
         eprintf (__VA_ARGS__);                                                                     \
         eprintf ("\n");                                                                            \
-        LOG_ERROR (__VA_ARGS__);                                                                   \
+        REAI_LOG_ERROR (__VA_ARGS__);                                                              \
     } while (0)
 
 

--- a/Source/Plugin.c
+++ b/Source/Plugin.c
@@ -492,16 +492,9 @@ Bool reai_plugin_check_config_exists() {
  * @param model
  * @param log_dir_path
  * */
-Bool reai_plugin_save_config (CString host, CString api_key, CString model) {
+Bool reai_plugin_save_config (CString host, CString api_key) {
     if (!reai_auth_check (reai(), reai_response(), host, api_key)) {
         DISPLAY_ERROR ("Invalid host or api-key provided. Please check once again and retry.");
-        return false;
-    }
-
-    // TODO: remove model from here, we'll fetch models here automatically from reveng.ai
-    // and save it by ourselves in the config
-    if (!model) {
-        DISPLAY_ERROR ("Provided model is invalid. Cannot save config.");
         return false;
     }
 
@@ -521,7 +514,6 @@ Bool reai_plugin_save_config (CString host, CString api_key, CString model) {
 
     fprintf (reai_config_file, "host         = \"%s\"\n", host);
     fprintf (reai_config_file, "apikey       = \"%s\"\n", api_key);
-    fprintf (reai_config_file, "model        = \"%s\"\n", model);
 
     fclose (reai_config_file);
 

--- a/Source/Plugin.c
+++ b/Source/Plugin.c
@@ -1347,7 +1347,7 @@ ReaiFunctionId
  * @return @c ReaiPluginTable containing search suggestions on success.
  * @return @c NULL when no suggestions found.
  * */
-ReaiPluginTable *reai_plugin_search_for_similar_functions (
+Bool reai_plugin_search_and_show_similar_functions (
     RzCore *core,
     CString fcn_name,
     Size    max_results_count,
@@ -1356,18 +1356,18 @@ ReaiPluginTable *reai_plugin_search_for_similar_functions (
 ) {
     if (!core) {
         DISPLAY_ERROR ("Invalid Rizin core porivded. Cannot perform similarity search.");
-        return NULL;
+        return false;
     }
 
     if (!fcn_name) {
         DISPLAY_ERROR ("Invalid function name porivded. Cannot perform similarity search.");
-        return NULL;
+        return false;
     }
 
     RzAnalysisFunction *fn = rz_analysis_get_function_byname (core->analysis, fcn_name);
     if (!fn) {
         DISPLAY_ERROR ("Provided function name does not exist. Cannot get similar function names.");
-        return NULL;
+        return false;
     }
 
     ReaiFunctionId fn_id = reai_plugin_get_function_id_for_rizin_function (core, fn);
@@ -1375,7 +1375,7 @@ ReaiPluginTable *reai_plugin_search_for_similar_functions (
         DISPLAY_ERROR (
             "Failed to get function id of given function. Cannot get similar function names."
         );
-        return NULL;
+        return false;
     }
 
     Float32            maxDistance = 1 - confidence;
@@ -1383,10 +1383,10 @@ ReaiPluginTable *reai_plugin_search_for_similar_functions (
         reai(),
         reai_response(),
         fn_id,
-        NULL,
+        NULL, // speculative fn ids
         max_results_count,
         maxDistance,
-        NULL,
+        NULL, // collections
         debug_mode
     );
 
@@ -1422,12 +1422,11 @@ ReaiPluginTable *reai_plugin_search_for_similar_functions (
             );
         });
 
-        return table;
+        reai_plugin_table_show (table);
+        reai_plugin_table_destroy (table);
+        return true;
     } else {
-        DISPLAY_INFO (
-            "Oops! I cannot find any function similar to this one. Try some other function?"
-        );
-        return NULL;
+        return false;
     }
 }
 

--- a/Source/Plugin.c
+++ b/Source/Plugin.c
@@ -280,13 +280,6 @@ Bool reai_plugin_init() {
         );
         return false;
     }
-
-    /* if invalid config is provided, then plugin fails to load. */
-    if (!reai_auth_check (reai(), reai_response(), reai_config()->host, reai_config()->apikey)) {
-        DISPLAY_ERROR ("Invalid API key or Host provided in configuration file.");
-        return false;
-    }
-
     /* initialize reai object. */
     reai() = reai_create (reai_config()->host, reai_config()->apikey, reai_config()->model);
     if (!reai()) {

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -53,7 +53,7 @@ extern "C" {
     void           reai_plugin_display_msg (ReaiLogLevel level, CString msg);
     Bool           reai_plugin_check_config_exists();
     CString        reai_plugin_get_default_log_dir_path();
-    Bool           reai_plugin_save_config (CString host, CString api_key, CString model);
+    Bool           reai_plugin_save_config (CString host, CString api_key);
 
     Bool reai_plugin_upload_opened_binary_file (RzCore* core);
     Bool reai_plugin_create_analysis_for_opened_binary_file (

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -76,8 +76,8 @@ extern "C" {
     );
     ReaiBinaryId reai_plugin_get_binary_id_for_opened_binary_file (RzCore* core);
     ReaiFunctionId
-        reai_plugin_get_function_id_for_rizin_function (RzCore* core, RzAnalysisFunction* fn);
-    ReaiPluginTable* reai_plugin_search_for_similar_functions (
+         reai_plugin_get_function_id_for_rizin_function (RzCore* core, RzAnalysisFunction* fn);
+    Bool reai_plugin_search_and_show_similar_functions (
         RzCore* core,
         CString fcn_name,
         Size    max_results,

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -35,9 +35,6 @@ extern "C" {
         Reai*         reai;
         ReaiResponse* reai_response;
         ReaiBinaryId  binary_id;
-
-        // Periodically updates the database in background
-        RzThread* background_worker;
     } ReaiPlugin;
 
     ReaiPlugin* reai_plugin();

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -30,16 +30,24 @@ extern "C" {
 /* plugin */
 #include <Table.h>
 
+    REAI_MAKE_VEC (ReaiBgWorkersVec, bg_workers, RzThread*, NULL, NULL);
+
     typedef struct ReaiPlugin {
         ReaiConfig*   reai_config;
         Reai*         reai;
         ReaiResponse* reai_response;
         ReaiBinaryId  binary_id;
+        CStrVec*      ai_models;
+
+        ReaiBgWorkersVec* bg_workers;
+        Bool              locked;
     } ReaiPlugin;
 
     ReaiPlugin* reai_plugin();
     Bool        reai_plugin_init();
     Bool        reai_plugin_deinit();
+
+    Bool reai_plugin_add_bg_work (RzThreadFunction fn, void* user_data);
 
     ReaiFnInfoVec* reai_plugin_get_function_boundaries (RzCore* core);
     void           reai_plugin_display_msg (ReaiLogLevel level, CString msg);
@@ -52,6 +60,7 @@ extern "C" {
         RzCore* core,
         CString prog_name,
         CString cmdline_args,
+        CString ai_model,
         Bool    is_private
     );
     ReaiAnalysisStatus reai_plugin_get_analysis_status_for_binary_id (ReaiBinaryId binary_id);
@@ -79,7 +88,6 @@ extern "C" {
 
     RzBinFile* reai_plugin_get_opened_binary_file (RzCore* core);
     CString    reai_plugin_get_opened_binary_file_path (RzCore* core);
-    ReaiModel  reai_plugin_get_ai_model_for_opened_binary_file (RzCore* core);
     CString    reai_plugin_get_opened_binary_file_path (RzCore* core);
     Uint64     reai_plugin_get_opened_binary_file_baseaddr (RzCore* core);
     Uint64     reai_plugin_get_rizin_analysis_function_count (RzCore* core);
@@ -88,10 +96,12 @@ extern "C" {
 
 // wrapper macros to make sure first call to any one of these
 // initializes plugin automatically
-#define reai()           reai_plugin()->reai
-#define reai_response()  reai_plugin()->reai_response
-#define reai_config()    reai_plugin()->reai_config
-#define reai_binary_id() reai_plugin()->binary_id
+#define reai()            reai_plugin()->reai
+#define reai_response()   reai_plugin()->reai_response
+#define reai_config()     reai_plugin()->reai_config
+#define reai_binary_id()  reai_plugin()->binary_id
+#define reai_ai_models()  reai_plugin()->ai_models
+#define reai_bg_workers() reai_plugin()->bg_workers
 
 #define DISPLAY_MSG(level, ...)                                                                    \
     do {                                                                                           \

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -34,7 +34,6 @@ extern "C" {
         ReaiConfig*   reai_config;
         Reai*         reai;
         ReaiResponse* reai_response;
-        ReaiLog*      reai_logger;
         ReaiBinaryId  binary_id;
 
         // Periodically updates the database in background
@@ -49,12 +48,7 @@ extern "C" {
     void           reai_plugin_display_msg (ReaiLogLevel level, CString msg);
     Bool           reai_plugin_check_config_exists();
     CString        reai_plugin_get_default_log_dir_path();
-    Bool           reai_plugin_save_config (
-                  CString host,
-                  CString api_key,
-                  CString model,
-                  CString log_dir_path
-              );
+    Bool           reai_plugin_save_config (CString host, CString api_key, CString model);
 
     Bool reai_plugin_upload_opened_binary_file (RzCore* core);
     Bool reai_plugin_create_analysis_for_opened_binary_file (
@@ -99,36 +93,18 @@ extern "C" {
 // initializes plugin automatically
 #define reai()           reai_plugin()->reai
 #define reai_response()  reai_plugin()->reai_response
-#define reai_logger()    reai_plugin()->reai_logger
 #define reai_config()    reai_plugin()->reai_config
 #define reai_binary_id() reai_plugin()->binary_id
 
-#define LOG_TRACE(...) REAI_LOG_TRACE (reai_logger(), __VA_ARGS__)
-#define LOG_INFO(...)  REAI_LOG_INFO (reai_logger(), __VA_ARGS__)
-#define LOG_DEBUG(...) REAI_LOG_DEBUG (reai_logger(), __VA_ARGS__)
-#define LOG_WARN(...)  REAI_LOG_WARN (reai_logger(), __VA_ARGS__)
-#define LOG_ERROR(...) REAI_LOG_ERROR (reai_logger(), __VA_ARGS__)
-#define LOG_FATAL(...) REAI_LOG_FATAL (reai_logger(), __VA_ARGS__)
-
-    /**
-     * Helper macro to create a buffer with contents of format string and given arguemtns
-     * with given name.
-     *
-     * @param strname Name of variable
-     * @param fmt Format string
-     * */
-#define FMT(strname, ...)                                                                          \
-    Size  strname##_##strsz = snprintf (0, 0, __VA_ARGS__) + 1;                                    \
-    Char* strname           = ALLOCATE (Char, strname##_##strsz);                                  \
-    if (!strname) {                                                                                \
-        PRINT_ERR (ERR_OUT_OF_MEMORY);                                                             \
-    } else {                                                                                       \
-        snprintf (strname, strname##_##strsz, __VA_ARGS__);                                        \
-    }
-
 #define DISPLAY_MSG(level, ...)                                                                    \
     do {                                                                                           \
-        FMT (msg, __VA_ARGS__);                                                                    \
+        Size  msgsz = snprintf (0, 0, __VA_ARGS__) + 1;                                            \
+        Char* msg   = ALLOCATE (Char, msgsz);                                                      \
+        if (!msg) {                                                                                \
+            PRINT_ERR (ERR_OUT_OF_MEMORY);                                                         \
+            break;                                                                                 \
+        }                                                                                          \
+        snprintf (msg, msgsz, __VA_ARGS__);                                                        \
         reai_plugin_display_msg (level, msg);                                                      \
         FREE (msg);                                                                                \
     } while (0)

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -62,13 +62,18 @@ extern "C" {
     Bool               reai_plugin_upload_opened_binary_file (RzCore* core);
     Bool               reai_plugin_create_analysis_for_opened_binary_file (RzCore* core);
     ReaiAnalysisStatus reai_plugin_get_analysis_status_for_binary_id (ReaiBinaryId binary_id);
-    Bool               reai_plugin_apply_existing_analysis (RzCore* core, ReaiBinaryId binary_id);
-    Bool               reai_plugin_auto_analyze_opened_binary_file (
-                      RzCore* core,
-                      Float64 max_distance,
-                      Size    max_results_per_function,
-                      Float64 min_confidence
+    Bool               reai_plugin_apply_existing_analysis (
+                      RzCore*      core,
+                      ReaiBinaryId binary_id,
+                      Bool         apply_to_all
                   );
+    Bool reai_plugin_auto_analyze_opened_binary_file (
+        RzCore* core,
+        Size    max_results_per_function,
+        Float64 min_confidence,
+        Bool    debug_mode,
+        Bool    apply_to_all
+    );
     ReaiBinaryId reai_plugin_get_binary_id_for_opened_binary_file (RzCore* core);
     ReaiFunctionId
         reai_plugin_get_function_id_for_rizin_function (RzCore* core, RzAnalysisFunction* fn);

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -28,6 +28,9 @@ extern "C" {
 #include <rz_bin.h>
 #include <rz_core.h>
 
+/* plugin */
+#include <Table.h>
+
     typedef struct ReaiPlugin {
         ReaiConfig*   reai_config;
         Reai*         reai;
@@ -69,6 +72,13 @@ extern "C" {
     ReaiBinaryId reai_plugin_get_binary_id_for_opened_binary_file (RzCore* core);
     ReaiFunctionId
         reai_plugin_get_function_id_for_rizin_function (RzCore* core, RzAnalysisFunction* fn);
+    ReaiPluginTable* reai_plugin_search_for_similar_functions (
+        RzCore* core,
+        CString fcn_name,
+        Size    max_results,
+        Float32 confidence,
+        Bool    debug_mode
+    );
 
     RzBinFile* reai_plugin_get_opened_binary_file (RzCore* core);
     CString    reai_plugin_get_opened_binary_file_path (RzCore* core);
@@ -76,8 +86,6 @@ extern "C" {
     CString    reai_plugin_get_opened_binary_file_path (RzCore* core);
     Uint64     reai_plugin_get_opened_binary_file_baseaddr (RzCore* core);
     Uint64     reai_plugin_get_rizin_analysis_function_count (RzCore* core);
-    RzAnalysisFunction*
-        reai_plugin_get_rizin_analysis_function_with_name (RzCore* core, CString name);
 
 #include "Override.h"
 

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -44,7 +44,7 @@ extern "C" {
     } ReaiPlugin;
 
     ReaiPlugin* reai_plugin();
-    Bool        reai_plugin_init();
+    Bool        reai_plugin_init (RzCore* core);
     Bool        reai_plugin_deinit();
 
     Bool reai_plugin_add_bg_work (RzThreadFunction fn, void* user_data);

--- a/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
+++ b/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
@@ -21,6 +21,10 @@ commands:
         entries:
           - text: "REi https://api.reveng.ai/v1 XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX binnet-0.4"
             comment: Initialize config with these settings. Replace v1 with the current version you want to use.
+  - name: REm
+    cname: list_available_ai_models
+    summary: Get all available models for analysis.
+    args: []
   - name: REh
     cname: health_check
     summary: Check connection status with RevEngAI servers.
@@ -37,6 +41,9 @@ commands:
         type: RZ_CMD_ARG_TYPE_STRING
         optional: false
       - name: cmd_line_args
+        type: RZ_CMD_ARG_TYPE_STRING
+        optional: false
+      - name: ai_model
         type: RZ_CMD_ARG_TYPE_STRING
         optional: false
     details:

--- a/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
+++ b/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
@@ -9,10 +9,13 @@ commands:
     args:
       - name: host
         type: RZ_CMD_ARG_TYPE_STRING
+        default_value: "https://api.reveng.ai/v1"
       - name: api_key
         type: RZ_CMD_ARG_TYPE_STRING
+        default_value: "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
       - name: model
         type: RZ_CMD_ARG_TYPE_STRING
+        default_value: "0.4"
     details:
       - name: Examples 
         entries:
@@ -29,7 +32,18 @@ commands:
   - name: REa
     cname: create_analysis
     summary: Upload and analyse currently loaded binary
-    args: []
+    args:
+      - name: prog_name
+        type: RZ_CMD_ARG_TYPE_STRING
+        optional: false
+      - name: cmd_line_args
+        type: RZ_CMD_ARG_TYPE_STRING
+        optional: false
+    details:
+      - name: Examples
+        entries:
+          - text: REa ffmpeg "-i input.mp4 -vf "fps=10,scale=320:-1:flags=lanczos" -c:v gif output.gif"
+            comment: "Create analysis for ffmpeg program with given command line arguments."
   - name: REau
     cname: ann_auto_analyze
     summary: Auto analyze binary functions using ANN and perform batch rename.
@@ -58,23 +72,6 @@ commands:
         entries:
           - text: "REap 18700"
             comment: "Apply analysis corresponding to bianry id 18700"
-  - name: REs
-    cname: get_analysis_status
-    summary: Get analysis status of given binary id
-    type: RZ_CMD_DESC_TYPE_ARGV_STATE
-    modes:
-      - RZ_OUTPUT_MODE_STANDARD
-    args:
-      - name: binary_id
-        type: RZ_CMD_ARG_TYPE_NUM
-        optional: true
-    details:
-      - name: Examples 
-        entries:
-          - text: "REs"
-            comment: "Check analysis status for currently opened binary file."
-          - text: "REs 18244"
-            comment: "Check analysis status for binary ID 18244"
   - name: REfl
     cname: get_basic_function_info
     summary: Get & show basic function info for selected binary.

--- a/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
+++ b/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
@@ -13,13 +13,10 @@ commands:
       - name: api_key
         type: RZ_CMD_ARG_TYPE_STRING
         default_value: "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-      - name: model
-        type: RZ_CMD_ARG_TYPE_STRING
-        default_value: "0.4"
     details:
       - name: Examples 
         entries:
-          - text: "REi https://api.reveng.ai/v1 XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX binnet-0.4"
+          - text: "REi https://api.reveng.ai/v1 XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
             comment: Initialize config with these settings. Replace v1 with the current version you want to use.
   - name: REm
     cname: list_available_ai_models

--- a/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
+++ b/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
@@ -110,6 +110,40 @@ commands:
         entries:
           - text: "fopen"
             comment: "New function name"
+  - name: REfs
+    cname: function_similarity_search
+    summary: RevEng.AI ANN functions similarity search.
+    args:
+      - name: function_name
+        type: RZ_CMD_ARG_TYPE_STRING
+        optional: false
+      - name: min_result_count
+        type: RZ_CMD_ARG_TYPE_NUM
+        default_value: 5
+      - name: min_confidence
+        type: RZ_CMD_ARG_TYPE_NUM
+        default_value: 0.9
+      - name: debug_mode 
+        type: RZ_CMD_ARG_TYPE_CHOICES
+        choices: ["true", "false"]
+        default_value: "true"
+    details:
+      - name: Function Name
+        entries:
+          - text: "fcn.1337"
+            comment: "Function to search similar functions for"
+      - name: Max Result Count 
+        entries:
+          - text: "10" 
+            comment: "Maximum number of search results"
+      - name: Min Confidence 
+        entries:
+          - text: "0.95"
+            comment: "Minimum confidence of search suggestions"
+      - name: Debug Mode Enable
+        entries:
+          - text: "true"
+            comment: "Suggest names taken from debugging symbols."
   - name: REart
     cname: show_revengai_art
     summary: Show RevEng.AI ASCII art.

--- a/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
+++ b/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
@@ -26,10 +26,6 @@ commands:
     cname: health_check
     summary: Check connection status with RevEngAI servers.
     args: []
-  - name: REu
-    cname: upload_bin
-    summary: Upload currently loaded binary to RevEngAI servers.
-    args: []
   - name: REa
     cname: create_analysis
     summary: Upload and analyse currently loaded binary
@@ -46,7 +42,7 @@ commands:
     details:
       - name: Examples
         entries:
-          - text: REa ffmpeg "-i input.mp4 -vf "fps=10,scale=320:-1:flags=lanczos" -c:v gif output.gif"
+          - text: REa ffmpeg "-i input.mp4 -c:v gif output.gif" binnet-0.4-x86-linux
             comment: "Create analysis for ffmpeg program with given command line arguments."
   - name: REau
     cname: ann_auto_analyze

--- a/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
+++ b/Source/Rizin/CmdGen/Yaml/Reai.yaml.in
@@ -14,18 +14,10 @@ commands:
       - name: model
         type: RZ_CMD_ARG_TYPE_STRING
     details:
-      - name: Host
+      - name: Examples 
         entries:
-          - text: https://api.reveng.ai/v1
-            comment: Replace v1 with the current version you want to use.
-      - name: API KEY
-        entries:
-          - text: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-            comment: API Key provided in RevEng.AI dashboard
-      - name: AI Model
-        entries:
-          - text: binnet-0.3
-            comment: Name and versionof AI model to be used.
+          - text: "REi https://api.reveng.ai/v1 XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX binnet-0.4"
+            comment: Initialize config with these settings. Replace v1 with the current version you want to use.
   - name: REh
     cname: health_check
     summary: Check connection status with RevEngAI servers.
@@ -34,9 +26,6 @@ commands:
     cname: upload_bin
     summary: Upload currently loaded binary to RevEngAI servers.
     args: []
-    #    - name: file_path
-    #      type: RZ_CMD_ARG_TYPE_STRING
-    #      optional: false
   - name: REa
     cname: create_analysis
     summary: Upload and analyse currently loaded binary
@@ -47,15 +36,16 @@ commands:
     modes:
       - RZ_OUTPUT_MODE_STANDARD
     args:
-      - name: distance
-        type: RZ_CMD_ARG_TYPE_NUM
-        default_value: 0.1
-      - name: results_per_function
-        type: RZ_CMD_ARG_TYPE_NUM
-        default_value: 5
       - name: min_confidence
         type: RZ_CMD_ARG_TYPE_NUM
-        default_value: 0.95
+        default_value: 90
+    details:
+      - name: Examples
+        entries:
+          - text: "REau"
+            comment: "Apply auto analysis to this binary with 90% min confidence"
+          - text: "REau 85"
+            comment: "Min 85% confidence"
   - name: REap
     cname: apply_existing_analysis 
     summary: Apply already existing RevEng.AI analysis to this binary.
@@ -64,10 +54,10 @@ commands:
         type: RZ_CMD_ARG_TYPE_NUM
         optional: false
     details:
-      - name: Binary ID 
+      - name: Examples 
         entries:
-          - text: "18700"
-            comment: "Binary ID of analysis to be applied"
+          - text: "REap 18700"
+            comment: "Apply analysis corresponding to bianry id 18700"
   - name: REs
     cname: get_analysis_status
     summary: Get analysis status of given binary id
@@ -79,12 +69,12 @@ commands:
         type: RZ_CMD_ARG_TYPE_NUM
         optional: true
     details:
-      - name: Binary ID
+      - name: Examples 
         entries:
-          - text: "18244"
-            comment: "Binary ID to check analysis status for"
-          - text: ""
-            comment: "No binary ID defaults to currently loaded binary"
+          - text: "REs"
+            comment: "Check analysis status for currently opened binary file."
+          - text: "REs 18244"
+            comment: "Check analysis status for binary ID 18244"
   - name: REfl
     cname: get_basic_function_info
     summary: Get & show basic function info for selected binary.
@@ -102,14 +92,10 @@ commands:
         type: RZ_CMD_ARG_TYPE_STRING
         optional: false
     details:
-      - name: Function address
+      - name: Examples
         entries:
-          - text: "0xf9da"
-            comment: "Address of function to be renamed"
-      - name: New name
-        entries:
-          - text: "fopen"
-            comment: "New function name"
+          - text: "REfr 0xf9da fopen"
+            comment: "Rename function at 0xf9da to fopen"
   - name: REfs
     cname: function_similarity_search
     summary: RevEng.AI ANN functions similarity search.
@@ -117,33 +103,16 @@ commands:
       - name: function_name
         type: RZ_CMD_ARG_TYPE_STRING
         optional: false
-      - name: min_result_count
-        type: RZ_CMD_ARG_TYPE_NUM
-        default_value: 5
       - name: min_confidence
         type: RZ_CMD_ARG_TYPE_NUM
-        default_value: 0.9
-      - name: debug_mode 
-        type: RZ_CMD_ARG_TYPE_CHOICES
-        choices: ["true", "false"]
-        default_value: "true"
+        default_value: 95
     details:
       - name: Function Name
         entries:
-          - text: "fcn.1337"
-            comment: "Function to search similar functions for"
-      - name: Max Result Count 
-        entries:
-          - text: "10" 
-            comment: "Maximum number of search results"
-      - name: Min Confidence 
-        entries:
-          - text: "0.95"
-            comment: "Minimum confidence of search suggestions"
-      - name: Debug Mode Enable
-        entries:
-          - text: "true"
-            comment: "Suggest names taken from debugging symbols."
+          - text: "REfs sym.main"
+            comment: "Search similar function for sym.main function with minimum confidence of 90%"
+          - text: "REfs __memcmp 95"
+            comment: "Search similar function for __memcmp, with minimum 95% confidence"
   - name: REart
     cname: show_revengai_art
     summary: Show RevEng.AI ASCII art.

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -59,16 +59,8 @@
  * */
 RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (core && argc);
+    REAI_LOG_TRACE ("[CMD] config initialize");
 
-    /* if file already exists then we don't make changes */
-    if (reai_plugin_check_config_exists()) {
-        DISPLAY_ERROR (
-            "Config file already exists. Remove/rename previous config to create new one."
-        );
-    }
-
-    /* no need to check whether these strings are empty or not in rizin
-     * because rizin shell automatically checks this */
     CString host    = argv[1];
     CString api_key = argv[2];
 
@@ -221,25 +213,18 @@ RZ_IPI RzCmdStatus rz_ann_auto_analyze_handler (
     }
 }
 
-/**
- * "REu"
- *
- * Upload a binary to RevEng.AI Servers. Checks for latest uploaded
- * binary already present in database and performs the upload operation
- * only if binary is not already uploaded.
- * */
-RZ_IPI RzCmdStatus rz_upload_bin_handler (RzCore* core, int argc, const char** argv) {
-    UNUSED (argc && argv);
-    REAI_LOG_TRACE ("[CMD] upload binary");
-
-    if (reai_plugin_upload_opened_binary_file (core)) {
-        DISPLAY_ERROR ("File upload successful.");
-        return RZ_CMD_STATUS_OK;
-    } else {
-        DISPLAY_ERROR ("File upload failed.");
-        return RZ_CMD_STATUS_ERROR;
-    }
-}
+/* RZ_IPI RzCmdStatus rz_upload_bin_handler (RzCore* core, int argc, const char** argv) { */
+/*     UNUSED (argc && argv); */
+/*     REAI_LOG_TRACE ("[CMD] upload binary"); */
+/**/
+/*     if (reai_plugin_upload_opened_binary_file (core)) { */
+/*         DISPLAY_ERROR ("File upload successful."); */
+/*         return RZ_CMD_STATUS_OK; */
+/*     } else { */
+/*         DISPLAY_ERROR ("File upload failed."); */
+/*         return RZ_CMD_STATUS_ERROR; */
+/*     } */
+/* } */
 
 /**
  * "REfl"

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -74,23 +74,16 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
     CString model   = argv[3];
 
     /* check whether API key is correct or not */
-    if (!reai_config_check_api_key (api_key)) {
+    if (!reai_auth_check (reai(), reai_response(), api_key)) {
         DISPLAY_ERROR (
-            "Invalid API key. API key must be in format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            "Invalid API key. Make sure you're online and directly copy-paste the API key from "
+            "RevEng.AI dashboard."
         );
         return RZ_CMD_STATUS_ERROR;
     }
 
-    CString log_dir_path = NULL;
-
-    log_dir_path = reai_plugin_get_default_log_dir_path();
-    if (!log_dir_path) {
-        DISPLAY_ERROR ("Failed to get log storage directory path.");
-        return RZ_CMD_STATUS_ERROR;
-    }
-
     /* attempt saving config */
-    if (reai_plugin_save_config (host, api_key, model, log_dir_path)) {
+    if (reai_plugin_save_config (host, api_key, model)) {
         /* try to reinit config after creating config */
         if (!reai_plugin_init()) {
             DISPLAY_ERROR ("Failed to init plugin after creating a new config.");
@@ -111,7 +104,7 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
  * */
 RZ_IPI RzCmdStatus rz_health_check_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (core && argc && argv);
-    LOG_TRACE ("[CMD] health check");
+    REAI_LOG_TRACE ("[CMD] health check");
 
     ReaiRequest request = {.type = REAI_REQUEST_TYPE_HEALTH_CHECK};
 
@@ -131,7 +124,7 @@ RZ_IPI RzCmdStatus rz_health_check_handler (RzCore* core, int argc, const char**
  * */
 RZ_IPI RzCmdStatus rz_create_analysis_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc && argv);
-    LOG_TRACE ("[CMD] create analysis");
+    REAI_LOG_TRACE ("[CMD] create analysis");
 
     Bool is_private;
     ASK_QUESTION (is_private, true, "Create private analysis?");
@@ -154,7 +147,7 @@ RZ_IPI RzCmdStatus rz_create_analysis_handler (RzCore* core, int argc, const cha
  * */
 RZ_IPI RzCmdStatus rz_apply_existing_analysis_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc && argv);
-    LOG_TRACE ("[CMD] apply existing analysis");
+    REAI_LOG_TRACE ("[CMD] apply existing analysis");
 
     Bool rename_unknown_only;
     ASK_QUESTION (rename_unknown_only, true, "Apply analysis only to unknown functions?");
@@ -181,7 +174,7 @@ RZ_IPI RzCmdStatus rz_ann_auto_analyze_handler (
     RzOutputMode output_mode
 ) {
     UNUSED (output_mode && argc);
-    LOG_TRACE ("[CMD] ANN Auto Analyze Binary");
+    REAI_LOG_TRACE ("[CMD] ANN Auto Analyze Binary");
 
     // NOTE: this is static here. I don't think it's a good command line option to have
     // Since user won't know about this when issuing the auto-analysis command.
@@ -221,7 +214,7 @@ RZ_IPI RzCmdStatus rz_ann_auto_analyze_handler (
  * */
 RZ_IPI RzCmdStatus rz_upload_bin_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc && argv);
-    LOG_TRACE ("[CMD] upload binary");
+    REAI_LOG_TRACE ("[CMD] upload binary");
 
     if (reai_plugin_upload_opened_binary_file (core)) {
         DISPLAY_ERROR ("File upload successful.");
@@ -250,7 +243,7 @@ RZ_IPI RzCmdStatus rz_get_basic_function_info_handler (
     RzOutputMode output_mode
 ) {
     UNUSED (argc && argv && output_mode);
-    LOG_TRACE ("[CMD] get basic function info");
+    REAI_LOG_TRACE ("[CMD] get basic function info");
 
     /* get file path of opened binary file */
     CString opened_file = reai_plugin_get_opened_binary_file_path (core);
@@ -320,7 +313,7 @@ RZ_IPI RzCmdStatus rz_get_basic_function_info_handler (
  * */
 RZ_IPI RzCmdStatus rz_rename_function_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc);
-    LOG_TRACE ("[CMD] rename function");
+    REAI_LOG_TRACE ("[CMD] rename function");
 
     Uint64  fn_addr  = rz_num_get (core->num, argv[1]);
     CString new_name = argv[2];

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -46,6 +46,8 @@
  * Requires a restart of rizin plugin after issue.
  * */
 RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const char** argv) {
+    UNUSED (argc);
+
     /* if file already exists then we don't make changes */
     if (reai_plugin_check_config_exists()) {
         DISPLAY_ERROR (
@@ -412,6 +414,35 @@ RZ_IPI RzCmdStatus rz_rename_function_handler (RzCore* core, int argc, const cha
     } else {
         DISPLAY_ERROR ("Failed to rename the function. Please check the function ID and new name.");
         return RZ_CMD_STATUS_ERROR;
+    }
+
+    return RZ_CMD_STATUS_OK;
+}
+
+/**
+ * "REfs"
+ *
+ * @b Similar function name search 
+ * */
+RZ_IPI RzCmdStatus
+    rz_function_similarity_search_handler (RzCore* core, int argc, const char** argv) {
+    UNUSED (argc);
+
+    CString function_name     = argv[1];
+    Uint32  max_results_count = rz_num_math (core->num, argv[2]);
+    Float32 min_confidence    = rz_num_math (core->num, argv[3]);
+    Bool    debug_mode        = !strncmp (argv[4], "true", 4) ? true : false;
+
+    ReaiPluginTable* results = reai_plugin_search_for_similar_functions (
+        core,
+        function_name,
+        max_results_count,
+        min_confidence,
+        debug_mode
+    );
+    if (results) {
+        reai_plugin_table_show (results);
+        reai_plugin_table_destroy (results);
     }
 
     return RZ_CMD_STATUS_OK;

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -169,12 +169,6 @@ RZ_IPI RzCmdStatus rz_health_check_handler (RzCore* core, int argc, const char**
  *
  * After getting the hash and making sure one latest instance of binary is already available,
  * we create analysis of the binary.
- *
- * TODO: compute sha256 hash of opened binary and check whether it matches the latest uploaded
- *       binary. If not then ask the user whether to perform a new upload or not.
- * TODO: check if an analysis already exists and whether user wants to reuse that analysis
- * TODO: check if analysis is already created. If not created then ask the user whether
- *       they really want to continue before analysis
  * */
 RZ_IPI RzCmdStatus rz_create_analysis_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc && argv);
@@ -250,9 +244,6 @@ RZ_IPI RzCmdStatus rz_ann_auto_analyze_handler (
  * Upload a binary to RevEng.AI Servers. Checks for latest uploaded
  * binary already present in database and performs the upload operation
  * only if binary is not already uploaded.
- *
- * TODO: compare latest hash in database with current hash of binary.
- *       if the don't match then ask the user what to do.
  * */
 RZ_IPI RzCmdStatus rz_upload_bin_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc && argv);
@@ -321,10 +312,7 @@ RZ_IPI RzCmdStatus rz_get_analysis_status_handler (
  * @b Get information about all functions detected by the AI model from
  *    RevEng.AI servers.
  *
- * TODO: take a binary id argument to get info of any analysis and not just
- *       currently opened analysis.
- *
- * NOTE: for now this works just for currently opened binary file. If binary
+ * NOTE: This works just for currently opened binary file. If binary
  *       file is not opened, this will return with `RZ_CMD_STATUS_ERROR`.
  *       If analysis for binary file does not exist then this will again return
  *       with an error.
@@ -467,17 +455,15 @@ RZ_IPI RzCmdStatus
     Bool debug_mode;
     ASK_QUESTION (debug_mode, true, "Enable debug symbol suggestions?");
 
-    ReaiPluginTable* results = reai_plugin_search_for_similar_functions (
-        core,
-        function_name,
-        max_results_count,
-        min_confidence,
-        debug_mode
-    );
-
-    if (results) {
-        reai_plugin_table_show (results);
-        reai_plugin_table_destroy (results);
+    if (!reai_plugin_search_and_show_similar_functions (
+            core,
+            function_name,
+            max_results_count,
+            min_confidence,
+            debug_mode
+        )) {
+        DISPLAY_ERROR ("Failed to get similar functions search result.");
+        return RZ_CMD_STATUS_ERROR;
     }
 
     return RZ_CMD_STATUS_OK;

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -71,10 +71,9 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
      * because rizin shell automatically checks this */
     CString host    = argv[1];
     CString api_key = argv[2];
-    CString model   = argv[3];
 
     /* attempt saving config */
-    if (reai_plugin_save_config (host, api_key, model)) {
+    if (reai_plugin_save_config (host, api_key)) {
         /* try to reinit config after creating config */
         if (!reai_plugin_init (core)) {
             DISPLAY_ERROR ("Failed to init plugin after creating a new config.");

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -73,15 +73,6 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
     CString api_key = argv[2];
     CString model   = argv[3];
 
-    /* check whether API key is correct or not */
-    if (!reai_auth_check (reai(), reai_response(), api_key)) {
-        DISPLAY_ERROR (
-            "Invalid API key. Make sure you're online and directly copy-paste the API key from "
-            "RevEng.AI dashboard."
-        );
-        return RZ_CMD_STATUS_ERROR;
-    }
-
     /* attempt saving config */
     if (reai_plugin_save_config (host, api_key, model)) {
         /* try to reinit config after creating config */
@@ -100,22 +91,18 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
 /**
  * "REh"
  *
- * @b Perform a health-check api call to check connection.
+ * @b Perform an auth-check api call to check connection.
  * */
 RZ_IPI RzCmdStatus rz_health_check_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (core && argc && argv);
     REAI_LOG_TRACE ("[CMD] health check");
 
-    ReaiRequest request = {.type = REAI_REQUEST_TYPE_HEALTH_CHECK};
-
-    if (!reai_request (reai(), &request, reai_response()) ||
-        !reai_response()->health_check.success) {
-        DISPLAY_ERROR ("Health check failed.");
+    if (!reai_auth_check (reai(), reai_response(), reai_config()->host, reai_config()->apikey)) {
+        DISPLAY_ERROR ("Authentication failed.");
         return RZ_CMD_STATUS_ERROR;
     }
 
-    printf ("OK\n");
-
+    rz_cons_println ("OK");
     return RZ_CMD_STATUS_OK;
 }
 

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -89,6 +89,22 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
 }
 
 /**
+ * "REm"
+ * */
+RZ_IPI RzCmdStatus rz_list_available_ai_models_handler (RzCore* core, int argc, const char** argv) {
+    UNUSED (core && argc && argv);
+    REAI_LOG_TRACE ("[CMD] list available ai models");
+
+    if (reai_ai_models()) {
+        REAI_VEC_FOREACH (reai_ai_models(), model, { rz_cons_println (*model); });
+        return RZ_CMD_STATUS_OK;
+    } else {
+        DISPLAY_ERROR ("Seems like background worker failed to get available AI models.");
+        return RZ_CMD_STATUS_ERROR;
+    }
+}
+
+/**
  * "REh"
  *
  * @b Perform an auth-check api call to check connection.
@@ -108,6 +124,9 @@ RZ_IPI RzCmdStatus rz_health_check_handler (RzCore* core, int argc, const char**
 
 /**
  * "REa"
+ *
+ * NOTE: The default way to get ai model would be to use "REm" command.
+ *       Get list of all available AI models and then use one to create a new analysis.
  * */
 RZ_IPI RzCmdStatus rz_create_analysis_handler (RzCore* core, int argc, const char** argv) {
     UNUSED (argc && argv);
@@ -118,11 +137,13 @@ RZ_IPI RzCmdStatus rz_create_analysis_handler (RzCore* core, int argc, const cha
 
     CString prog_name    = argv[1];
     CString cmdline_args = argv[2];
+    CString ai_model     = argv[3];
 
     return reai_plugin_create_analysis_for_opened_binary_file (
                core,
                prog_name,
                cmdline_args,
+               ai_model,
                is_private
            ) ?
                RZ_CMD_STATUS_OK :

--- a/Source/Rizin/CmdHandlers.c
+++ b/Source/Rizin/CmdHandlers.c
@@ -76,7 +76,7 @@ RZ_IPI RzCmdStatus rz_plugin_initialize_handler (RzCore* core, int argc, const c
     /* attempt saving config */
     if (reai_plugin_save_config (host, api_key, model)) {
         /* try to reinit config after creating config */
-        if (!reai_plugin_init()) {
+        if (!reai_plugin_init (core)) {
             DISPLAY_ERROR ("Failed to init plugin after creating a new config.");
             return RZ_CMD_STATUS_ERROR;
         }
@@ -139,15 +139,20 @@ RZ_IPI RzCmdStatus rz_create_analysis_handler (RzCore* core, int argc, const cha
     CString cmdline_args = argv[2];
     CString ai_model     = argv[3];
 
-    return reai_plugin_create_analysis_for_opened_binary_file (
-               core,
-               prog_name,
-               cmdline_args,
-               ai_model,
-               is_private
-           ) ?
-               RZ_CMD_STATUS_OK :
-               RZ_CMD_STATUS_ERROR;
+    if (reai_plugin_create_analysis_for_opened_binary_file (
+            core,
+            prog_name,
+            cmdline_args,
+            ai_model,
+            is_private
+        )) {
+        DISPLAY_INFO ("Analysis created sucessfully");
+        return RZ_CMD_STATUS_OK;
+    }
+
+    DISPLAY_ERROR ("Failed to create analysis");
+
+    return RZ_CMD_STATUS_ERROR;
 }
 
 /**
@@ -160,13 +165,17 @@ RZ_IPI RzCmdStatus rz_apply_existing_analysis_handler (RzCore* core, int argc, c
     Bool rename_unknown_only;
     ASK_QUESTION (rename_unknown_only, true, "Apply analysis only to unknown functions?");
 
-    return reai_plugin_apply_existing_analysis (
-               core,
-               rz_num_get (core->num, argv[1]), // binary id
-               !rename_unknown_only             // apply analysis to all?
-           ) ?
-               RZ_CMD_STATUS_OK :
-               RZ_CMD_STATUS_ERROR;
+    if (reai_plugin_apply_existing_analysis (
+            core,
+            rz_num_get (core->num, argv[1]), // binary id
+            !rename_unknown_only             // apply analysis to all?
+        )) {
+        DISPLAY_INFO ("Existing analysis applied sucessfully");
+        return RZ_CMD_STATUS_OK;
+    }
+
+    DISPLAY_INFO ("Failed to apply existing analysis");
+    return RZ_CMD_STATUS_ERROR;
 }
 
 /**

--- a/Source/Rizin/Rizin.c
+++ b/Source/Rizin/Rizin.c
@@ -19,7 +19,6 @@
 
 /* revengai */
 #include <Reai/AnalysisInfo.h>
-#include <Reai/Db.h>
 #include <Reai/Log.h>
 #include <Reai/Api/Api.h>
 #include <Reai/Common.h>
@@ -66,8 +65,8 @@ RZ_IPI Bool rz_plugin_init (RzCore* core) {
     }
 
     rzshell_cmddescs_init (core);
-    if(!reai_plugin_init (core)) {
-        DISPLAY_ERROR("Failed to initialize plugin.");
+    if (!reai_plugin_init()) {
+        DISPLAY_ERROR ("Failed to initialize plugin.");
     }
 
     return true;
@@ -82,7 +81,7 @@ RZ_IPI Bool rz_plugin_fini (RzCore* core) {
         return false;
     }
 
-    reai_plugin_deinit (core);
+    reai_plugin_deinit();
 
     /* Remove command group from rzshell. The name of this comamnd group must match
      * with the one specified in Root.yaml */

--- a/Source/Rizin/Rizin.c
+++ b/Source/Rizin/Rizin.c
@@ -44,12 +44,12 @@
  * */
 void reai_plugin_display_msg (ReaiLogLevel level, CString msg) {
     if (!msg) {
-        DISPLAY_ERROR ("Invalid message. Cannot display.");
+        REAI_LOG_ERROR (ERR_INVALID_ARGUMENTS);
         return;
     }
 
-    rz_cons_printf ("%s\n", msg);
-    reai_log_printf (reai_logger(), level, "display", msg);
+    rz_cons_println (msg);
+    reai_log_printf (level, "rizin.display", msg);
 }
 
 /**

--- a/Source/Rizin/Rizin.c
+++ b/Source/Rizin/Rizin.c
@@ -65,7 +65,7 @@ RZ_IPI Bool rz_plugin_init (RzCore* core) {
     }
 
     rzshell_cmddescs_init (core);
-    if (!reai_plugin_init()) {
+    if (!reai_plugin_init (core)) {
         DISPLAY_ERROR ("Failed to initialize plugin.");
     }
 

--- a/Source/Rizin/Table.c
+++ b/Source/Rizin/Table.c
@@ -252,3 +252,29 @@ ReaiPluginTable* reai_plugin_table_set_title (ReaiPluginTable* table, CString ti
 
     return table;
 }
+
+/**
+ * @b Clear table contents.
+ *
+ * @param table.
+ *
+ * @return @c table on success.
+ * @return @c NULL otherwise.
+ * */
+ReaiPluginTable* reai_plugin_table_clear_contents (ReaiPluginTable* table) {
+    if (!table) {
+        DISPLAY_ERROR ("Invalid table provided.");
+        return NULL;
+    }
+
+    // easiest way to clear contents is to recreate a new table
+    RzTable* new_table = rz_table_new();
+    if (new_table) {
+        rz_table_free (table->table);
+        table->table = new_table;
+        return table;
+    } else {
+        DISPLAY_ERROR ("Failed to clear table contents");
+        return NULL;
+    }
+}

--- a/Source/Table.h
+++ b/Source/Table.h
@@ -34,6 +34,7 @@ extern "C" {
     ReaiPluginTable*
         reai_plugin_table_set_columnsf (ReaiPluginTable* table, const char* fmtstr, ...);
     ReaiPluginTable* reai_plugin_table_add_rowf (ReaiPluginTable* table, const char* fmtstr, ...);
+    ReaiPluginTable* reai_plugin_table_clear_contents (ReaiPluginTable* table);
     void             reai_plugin_table_show (ReaiPluginTable* table);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Updates : 
- Add function similarity search feature in Rizin plugin as well, existed in Cutter
- Improve Rizin plugin commands by reducing command line arguments. Necessary boolean input taken as question form from console
- Ask user questions before applying analysis (existing or auto-analysis)
- Make `Dockerfile` use `v1` branch of `creait` for now
- Auto analysis is now configurable using a dialog in Cutter. In Rizin, we just take confidence and rest questions are asked by yes/no questions from console input
- Remove local database
- Remove upload file feature from Rizin & Cutter. FIle is uploaded only when a new analysis is created. It does not make sense to only upload a binary.
- Remove show analysis status feature from Rizin & Cutter. Analysis status is better checked from RevEng.AI dashboard.
- Now to use most of the plugin features (like auto-analyze, function search, etc...), one needs to either create a new analysis, or apply an existing analysis. This needs to be done every time user loads a new binary for analysis.
- Creating a new analysis now opens up a new dialog to configure some settings like binary name, command line args and whether the analysis should be private or not.
- Logger now captures what happens inside `creait` library as well. Earlier it was just capturing what happens in `reai-rz`
- Auth check api endpoint used in verifying host and api-key
- Get latest AI model version number and use that to create analysis. The model names are fetched in background when the plugin starts loading.
- Save binary ID in `RzProject`. Project needs to be saved by user. Other methods are to create a new analysis or to apply an existing analysis to current binary.
- Remove model from plugin config file. Models are now loaded when plugin loads and when creating analysis, provided as a list (cutter) or through a command (rizin). User needs to either select the model (cutter) or write the model string (rizin)

TODO:
- Spwan new threads when applying existing analysis, performing auto-analysis, or when creating a new analysis (uploading file).
- Update README with screenshots