### PR TITLE
Rizin & Cutter Function Rename Hook

### DIFF
--- a/Source/Cutter/Cutter.cpp
+++ b/Source/Cutter/Cutter.cpp
@@ -873,10 +873,10 @@ void ReaiCutterPlugin::onStartupAnalysisFound (const QVector<AnalysisInfo> &matc
                 QString ("Applied existing analysis (Binary ID: %1)").arg (selectedId),
                 true
             );
+            mainWindow->refreshAll();
             break;
         }
         case AnalysisSelectionDialog::CreateNew :
-            // Open CreateAnalysisDialog
             on_CreateAnalysis();
             break;
         case AnalysisSelectionDialog::Cancel :
@@ -1264,6 +1264,10 @@ void AnalysisSelectionDialog::onUseExistingClicked() {
     int currentRow = analysisTable->currentRow();
     if (currentRow >= 0 && currentRow < analysisData.size()) {
         selectedAnalysisId = analysisData[currentRow].binary_id;
+
+        RzCoreLocked core (Core());
+        rzApplyAnalysis (core, selectedAnalysisId);
+
         selectionResult    = UseExisting;
         accept();
     }

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -61,6 +61,18 @@ extern "C" {
     void     SetBinaryId (BinaryId binary_id);
 
     ///
+    /// Get binary ID with RzCore fallback for cross-context access.
+    ///
+    /// core[in] : RzCore instance to get config from if local storage unavailable.
+    ///
+    /// SUCCESS : A non-zero binary ID if found locally or in RzCore config.
+    /// FAILURE : 0.
+    ///
+    BinaryId GetBinaryIdFromCore (RzCore *core);
+    void     SetBinaryIdInCore (RzCore *core, BinaryId binary_id);
+
+
+    ///
     /// Get all available AI models.
     ///
     /// SUCCESS : Vector of ModelInfo objects filled with valid data.


### PR DESCRIPTION
Provide a callback function that'll be called by rizin core whenever a function rename event occurs. The callback then gets new function names and automatically syncs the current Rizin/Cutter session with RevEngAI keeping the local and remote session always in sync.